### PR TITLE
Upgrade to BaseX v11

### DIFF
--- a/API.html
+++ b/API.html
@@ -1,0 +1,558 @@
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en">
+   <head>
+      <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+      <title>TAPAS-xq API</title>
+      <style>
+          body {
+            font-family: Verdana, Helvetica, Arial, sans-serif;
+            margin: 0 0 1rem;
+            padding: 0 2rem;
+          }
+          section { margin: 1.5rem 0 2rem; }
+          .endpoint { font-size: 1.125em; }
+          .endpoint .param { color: #cb0000; }
+          .param {
+            font-family: monospace;
+            font-size: 1.1em;
+          }
+          table.function-params { 
+            border: thin solid #333;
+            border-collapse: collapse;
+            margin: 0 1rem;
+            width: 100%;
+          }
+          caption {
+            font-size: 1.1em;
+            padding: 0.25em 0 0.5em;
+          }
+          th, td {
+            padding: 0.35rem;
+            vertical-align: baseline;
+          }
+          thead th { border-bottom: thin solid gray; }
+          th.param { text-align: right; }
+          td { padding-left: 0.5rem; }
+          dd + dt.param { margin-top: 0.35rem; }
+        </style>
+   </head>
+   <body>
+      <aside>
+         <p>This documentation was generated from its <a href="https://github.com/NEU-DSG/tapas-xq/blob/develop/modules/tapas-api.xql">source code</a> on June 27th, 2024, 2:53 p.m. GMT-04:00.</p>
+      </aside>
+      <main>
+         <h1>API documentation</h1>
+         <p>This is the API for TAPAS-xq, the XML database component of TAPAS. TAPAS-xq stores
+            TEI documents, 
+            indexes them, and generates derivatives such as MODS metadata and reading interface
+            XHTML.</p>
+         <p>TAPAS-xq also maintains a registry of “<a href="https://github.com/NEU-DSG/tapas-view-packages">view 
+               packages</a>”. Each view package includes: a program for generating a “view” (a web page); web
+            assets 
+            for displaying that page; and a configuration file describing these contents. TAPAS-xq
+            is mostly 
+            concerned with the program component, and the configuration file which defines how
+            to execute that 
+            program.</p>
+         <p>All POST and DELETE requests <strong>must</strong> include an Authentication header containing the 
+            credentials for a BaseX user with write access to the TAPAS databases. If a request
+            doesn’t meet this
+            criteria, a response with an HTTP status code 401 will be returned.</p>
+         <h2 id="all-endpoints">Request endpoints</h2>
+         <section aria-labelledby="section_get-documentation">
+            <h3 id="section_get-documentation">Get documentation</h3>
+            <p><code class="endpoint">GET /tapas-xq/api</code></p>
+            <p>Generate documentation for the TAPAS-xq API, in XHTML or Markdown.</p>
+            <p>This endpoint returns a representation of the API documentation, with status code 200.</p>
+            <table class="function-params">
+               <caption>Request settings</caption>
+               <thead>
+                  <tr>
+                     <th style="min-width:10%;">Name</th>
+                     <th>Description</th>
+                     <th>Where to set value</th>
+                  </tr>
+               </thead>
+               <tbody>
+                  <tr>
+                     <th scope="row" class="param">format</th>
+                     <td>The formatting method to use when producing documentation. Valid options are 
+                        "markdown" or "html". The default is to return XHTML.</td>
+                     <td>query parameter</td>
+                  </tr>
+               </tbody>
+            </table>
+         </section>
+         <section aria-labelledby="section_store-core-file-and-supplementals">
+            <h3 id="section_store-core-file-and-supplementals">Store core file and supplementals</h3>
+            <p><code class="endpoint">POST /tapas-xq/<strong class="param">project-id</strong>/<strong class="param">doc-id</strong></code></p>
+            <p>Store a TEI record into the XML database, as well as MODS metadata and “TAPAS-friendly
+               environment” 
+               (TFE) metadata. The generated MODS metadata record is also returned in the HTTP response.</p>
+            <p>This endpoint is a convenient wrapper for the “Store core file”, “Store core file
+               object 
+               description”, and “Store core file contextual metadata” endpoints. When a core file
+               is initially 
+               created, this endpoint alone will suffice to generate everything needed by TAPAS-xq
+               and Rails.</p>
+            <p>This endpoint returns the MODS record derived from the TEI file, with HTTP status code 201. Any problems
+               with the 
+               TEI file will result in a response code of 500. If the MODS file could not be generated
+               due to 
+               transformation issues, the TEI and TFE files will still be stored despite the response
+               error code.</p>
+            <table class="function-params">
+               <caption>Request settings</caption>
+               <thead>
+                  <tr>
+                     <th style="min-width:10%;">Name</th>
+                     <th>Description</th>
+                     <th>Where to set value</th>
+                  </tr>
+               </thead>
+               <tbody>
+                  <tr>
+                     <th scope="row" class="param">project-id</th>
+                     <td>The unique identifier of the project which owns the work.</td>
+                     <td>URL</td>
+                  </tr>
+                  <tr>
+                     <th scope="row" class="param">doc-id</th>
+                     <td>A unique identifier for the document record attached to the original TEI document
+                        and 
+                        its derivatives.</td>
+                     <td>URL</td>
+                  </tr>
+                  <tr>
+                     <th scope="row" class="param">file</th>
+                     <td>The TEI-encoded XML document to be stored.</td>
+                     <td>form parameter</td>
+                  </tr>
+                  <tr>
+                     <th scope="row" class="param">collections</th>
+                     <td>Comma-separated list of collection identifiers with which the work should be 
+                        associated.</td>
+                     <td>form parameter</td>
+                  </tr>
+                  <tr>
+                     <th scope="row" class="param">is-public</th>
+                     <td>Optional. Value of “true” or “false”. Indicates if the XML document should be 
+                        queryable by the public. By default, the document is considered private. (Note that
+                        if the 
+                        document belongs to even one public collection, it should be queryable.)</td>
+                     <td>form parameter</td>
+                  </tr>
+                  <tr>
+                     <th scope="row" class="param">title</th>
+                     <td>Optional. The work’s title as it should appear in TAPAS metadata.</td>
+                     <td>form parameter</td>
+                  </tr>
+                  <tr>
+                     <th scope="row" class="param">authors</th>
+                     <td>Optional. A list of authors’ names as they should appear in TAPAS metadata, separated
+                        
+                        by vertical bars.</td>
+                     <td>form parameter</td>
+                  </tr>
+                  <tr>
+                     <th scope="row" class="param">contributors</th>
+                     <td>Optional. A list of contributors’ names as they should appear in TAPAS metadata, 
+                        separated by vertical bars.</td>
+                     <td>form parameter</td>
+                  </tr>
+               </tbody>
+            </table>
+         </section>
+         <section aria-labelledby="section_store-core-file">
+            <h3 id="section_store-core-file">Store core file</h3>
+            <p><code class="endpoint">POST /tapas-xq/<strong class="param">project-id</strong>/<strong class="param">doc-id</strong>/tei</code></p>
+            <p>Store a TEI document.</p>
+            <p>This endpoint returns a URL path for accessing the stored TEI file through the TAPAS-xq API, with status
+               code 201.</p>
+            <table class="function-params">
+               <caption>Request settings</caption>
+               <thead>
+                  <tr>
+                     <th style="min-width:10%;">Name</th>
+                     <th>Description</th>
+                     <th>Where to set value</th>
+                  </tr>
+               </thead>
+               <tbody>
+                  <tr>
+                     <th scope="row" class="param">project-id</th>
+                     <td>The unique identifier of the project which owns the work.</td>
+                     <td>URL</td>
+                  </tr>
+                  <tr>
+                     <th scope="row" class="param">doc-id</th>
+                     <td>A unique identifier for the document record attached to the original TEI document
+                        and 
+                        its derivatives (MODS, TFE).</td>
+                     <td>URL</td>
+                  </tr>
+                  <tr>
+                     <th scope="row" class="param">file</th>
+                     <td>The TEI-encoded XML document to be stored.</td>
+                     <td>form parameter</td>
+                  </tr>
+               </tbody>
+            </table>
+         </section>
+         <section aria-labelledby="section_store-core-file-object-description">
+            <h3 id="section_store-core-file-object-description">Store core file object description</h3>
+            <p><code class="endpoint">POST /tapas-xq/<strong class="param">project-id</strong>/<strong class="param">doc-id</strong>/mods</code></p>
+            <p>Construct a MODS metadata record using the TEI header and any additional information
+               provided in the 
+               request. Store the MODS in the database alongside its core file TEI.</p>
+            <p>The TEI core file must be stored <em>before</em> any of its derivatives.</p>
+            <p>This endpoint returns the MODS record derived from the TEI file, with status code 201. If no TEI document
+               is 
+               associated with the given <code class="param">doc-id</code>, the response will have a status code 
+               of 500.</p>
+            <table class="function-params">
+               <caption>Request settings</caption>
+               <thead>
+                  <tr>
+                     <th style="min-width:10%;">Name</th>
+                     <th>Description</th>
+                     <th>Where to set value</th>
+                  </tr>
+               </thead>
+               <tbody>
+                  <tr>
+                     <th scope="row" class="param">project-id</th>
+                     <td>The unique identifier of the project which owns the work.</td>
+                     <td>URL</td>
+                  </tr>
+                  <tr>
+                     <th scope="row" class="param">doc-id</th>
+                     <td>A unique identifier for the document record attached to the original TEI document
+                        and 
+                        its derivatives.</td>
+                     <td>URL</td>
+                  </tr>
+                  <tr>
+                     <th scope="row" class="param">title</th>
+                     <td>Optional. The work’s title as it should appear in TAPAS metadata.</td>
+                     <td>form parameter</td>
+                  </tr>
+                  <tr>
+                     <th scope="row" class="param">authors</th>
+                     <td>Optional. A list of authors’ names as they should appear in TAPAS metadata, separated
+                        
+                        by vertical bars.</td>
+                     <td>form parameter</td>
+                  </tr>
+                  <tr>
+                     <th scope="row" class="param">contributors</th>
+                     <td>Optional. A list of contributors’ names as they should appear in TAPAS metadata, 
+                        separated by vertical bars.</td>
+                     <td>form parameter</td>
+                  </tr>
+               </tbody>
+            </table>
+         </section>
+         <section aria-labelledby="section_store-core-file-contextual-metadata">
+            <h3 id="section_store-core-file-contextual-metadata">Store core file contextual metadata</h3>
+            <p><code class="endpoint">POST /tapas-xq/<strong class="param">project-id</strong>/<strong class="param">doc-id</strong>/tfe</code></p>
+            <p>Store “TAPAS-friendly environment” (TFE) metadata. Triggers the generation of a small
+               XML file 
+               containing useful information about the context of the TEI document, such as its parent
+               project.</p>
+            <p>The TEI core file must be stored <em>before</em> any of its derivatives.</p>
+            <p>This endpoint returns a URL path for reading the new TFE file through the TAPAS-xq API, with status code
+               201. If 
+               no TEI document is associated with the given <code class="param">doc-id</code>, the response will 
+               have a status code of 500.</p>
+            <table class="function-params">
+               <caption>Request settings</caption>
+               <thead>
+                  <tr>
+                     <th style="min-width:10%;">Name</th>
+                     <th>Description</th>
+                     <th>Where to set value</th>
+                  </tr>
+               </thead>
+               <tbody>
+                  <tr>
+                     <th scope="row" class="param">project-id</th>
+                     <td>The unique identifier of the project which owns the work.</td>
+                     <td>URL</td>
+                  </tr>
+                  <tr>
+                     <th scope="row" class="param">doc-id</th>
+                     <td>A unique identifier for the document record attached to the original TEI document
+                        and 
+                        its derivatives.</td>
+                     <td>URL</td>
+                  </tr>
+                  <tr>
+                     <th scope="row" class="param">collections</th>
+                     <td>Comma-separated list of collection identifiers with which the work should be 
+                        associated.</td>
+                     <td>form parameter</td>
+                  </tr>
+                  <tr>
+                     <th scope="row" class="param">is-public</th>
+                     <td>Optional. Value of “true” or “false”. Indicates if the XML document should be 
+                        queryable by the public. By default, the document is considered private. (Note that
+                        if the 
+                        document belongs to even one public collection, it should be queryable.)</td>
+                     <td>form parameter</td>
+                  </tr>
+               </tbody>
+            </table>
+         </section>
+         <section aria-labelledby="section_derive-reader">
+            <h3 id="section_derive-reader">Derive reader</h3>
+            <p><code class="endpoint">POST /tapas-xq/derive-reader/<strong class="param">type</strong></code></p>
+            <p>Given the name of a TAPAS view package, generate an XHTML file from the provided TEI
+               document. The 
+               generated XHTML is not a full webpage but a <code>&lt;div&gt;</code> snippet, suitable for inclusion 
+               in the TAPAS reading interface. </p>
+            <p>The XML database does not store any files as a result of this request.</p>
+            <p>Note that additional form parameters may be available, depending on the view package
+               selected. Check 
+               the view package’s configuration file for additional parameters.</p>
+            <p>This endpoint returns generated XHTML with status code 200.</p>
+            <table class="function-params">
+               <caption>Request settings</caption>
+               <thead>
+                  <tr>
+                     <th style="min-width:10%;">Name</th>
+                     <th>Description</th>
+                     <th>Where to set value</th>
+                  </tr>
+               </thead>
+               <tbody>
+                  <tr>
+                     <th scope="row" class="param">type</th>
+                     <td>A keyword representing the type of reader view to generate. Valid keywords can be
+                        found 
+                        by making a request to  the “List registered view packages” endpoint.</td>
+                     <td>URL</td>
+                  </tr>
+                  <tr>
+                     <th scope="row" class="param">file</th>
+                     <td>A TEI-encoded XML document. If, in the future, a view package makes use of a different
+                        
+                        input source (such as a TAPAS collection or a project), the file parameter may become
+                        optional.</td>
+                     <td>form parameter</td>
+                  </tr>
+               </tbody>
+            </table>
+         </section>
+         <section aria-labelledby="section_read-core-file">
+            <h3 id="section_read-core-file">Read core file</h3>
+            <p><code class="endpoint">GET /tapas-xq/<strong class="param">project-id</strong>/<strong class="param">doc-id</strong>/tei</code></p>
+            <p>Retrieve a TEI file stored in the XML database.</p>
+            <p>This endpoint returns a copy of the TEI file, with status code 200. If the file does not exist, the response
+               will 
+               have a status code of 404.</p>
+            <p>If the file is marked as private in the contextual metadata (TFE file), only users
+               with write 
+               access to the database will be able to access the file. An attempt at unauthorized
+               access will 
+               yield a 403 status code and error.</p>
+            <table class="function-params">
+               <caption>Request settings</caption>
+               <thead>
+                  <tr>
+                     <th style="min-width:10%;">Name</th>
+                     <th>Description</th>
+                     <th>Where to set value</th>
+                  </tr>
+               </thead>
+               <tbody>
+                  <tr>
+                     <th scope="row" class="param">project-id</th>
+                     <td>The identifier of the project which owns the core file.</td>
+                     <td>URL</td>
+                  </tr>
+                  <tr>
+                     <th scope="row" class="param">doc-id</th>
+                     <td>The identifier of the TEI core file.</td>
+                     <td>URL</td>
+                  </tr>
+               </tbody>
+            </table>
+         </section>
+         <section aria-labelledby="section_read-core-file-object-description">
+            <h3 id="section_read-core-file-object-description">Read core file object description</h3>
+            <p><code class="endpoint">GET /tapas-xq/<strong class="param">project-id</strong>/<strong class="param">doc-id</strong>/mods</code></p>
+            <p>Retrieve a MODS file associated with a given core file identifier.</p>
+            <p>This endpoint returns a copy of the MODS metadata, with status code 200. If the file does not exist, the
+               response 
+               will have a status code of 404.</p>
+            <p>If the file is marked as private in the contextual metadata (TFE file), only users
+               with write 
+               access to the database will be able to access the file. An attempt at unauthorized
+               access will 
+               yield a 403 status code and error.</p>
+            <table class="function-params">
+               <caption>Request settings</caption>
+               <thead>
+                  <tr>
+                     <th style="min-width:10%;">Name</th>
+                     <th>Description</th>
+                     <th>Where to set value</th>
+                  </tr>
+               </thead>
+               <tbody>
+                  <tr>
+                     <th scope="row" class="param">project-id</th>
+                     <td>The identifier of the project which owns the core file.</td>
+                     <td>URL</td>
+                  </tr>
+                  <tr>
+                     <th scope="row" class="param">doc-id</th>
+                     <td>The identifier of the TEI core file.</td>
+                     <td>URL</td>
+                  </tr>
+               </tbody>
+            </table>
+         </section>
+         <section aria-labelledby="section_read-core-file-contextual-metadata">
+            <h3 id="section_read-core-file-contextual-metadata">Read core file contextual metadata</h3>
+            <p><code class="endpoint">GET /tapas-xq/<strong class="param">project-id</strong>/<strong class="param">doc-id</strong>/tfe</code></p>
+            <p>Retrieve a TAPAS-friendly environment (TFE) file associated with a given core file
+               identifier.</p>
+            <p>This endpoint returns a copy of the TFE metadata, with status code 200. If the file does not exist, the
+               response 
+               will have a status code of 404.</p>
+            <p>If the file is marked as private in the contextual metadata (TFE file), only users
+               with write 
+               access to the database will be able to access the file. An attempt at unauthorized
+               access will 
+               yield a 403 status code and error.</p>
+            <table class="function-params">
+               <caption>Request settings</caption>
+               <thead>
+                  <tr>
+                     <th style="min-width:10%;">Name</th>
+                     <th>Description</th>
+                     <th>Where to set value</th>
+                  </tr>
+               </thead>
+               <tbody>
+                  <tr>
+                     <th scope="row" class="param">project-id</th>
+                     <td>The identifier of the project which owns the core file.</td>
+                     <td>URL</td>
+                  </tr>
+                  <tr>
+                     <th scope="row" class="param">doc-id</th>
+                     <td>The identifier of the TEI core file.</td>
+                     <td>URL</td>
+                  </tr>
+               </tbody>
+            </table>
+         </section>
+         <section aria-labelledby="section_delete-core-file">
+            <h3 id="section_delete-core-file">Delete core file</h3>
+            <p><code class="endpoint">DELETE /tapas-xq/<strong class="param">project-id</strong>/<strong class="param">doc-id</strong></code></p>
+            <p>Completely remove all database records associated with a given TEI core file identifier:
+               TEI file, 
+               MODS metadata, and TAPAS-friendly environment record.</p>
+            <p>This endpoint returns a short confirmation in XML that the resources will be deleted, with status code 202.
+               If no 
+               TEI document is associated with the given identifier, the response will have a status
+               code of 500.</p>
+            <table class="function-params">
+               <caption>Request settings</caption>
+               <thead>
+                  <tr>
+                     <th style="min-width:10%;">Name</th>
+                     <th>Description</th>
+                     <th>Where to set value</th>
+                  </tr>
+               </thead>
+               <tbody>
+                  <tr>
+                     <th scope="row" class="param">project-id</th>
+                     <td>The identifier of the project which owns the core file.</td>
+                     <td>URL</td>
+                  </tr>
+                  <tr>
+                     <th scope="row" class="param">doc-id</th>
+                     <td>The identifier of the TEI core file.</td>
+                     <td>URL</td>
+                  </tr>
+               </tbody>
+            </table>
+         </section>
+         <section aria-labelledby="section_delete-project-documents">
+            <h3 id="section_delete-project-documents">Delete project documents</h3>
+            <p><code class="endpoint">DELETE /tapas-xq/<strong class="param">project-id</strong></code></p>
+            <p>Completely remove all database records associated with the given TAPAS project.</p>
+            <p>This endpoint returns a short confirmation in XML that the resources will be deleted, with status code 202.
+               If no 
+               TEI document is associated with the given identifier, the response will have a status
+               code of 500.</p>
+            <table class="function-params">
+               <caption>Request settings</caption>
+               <thead>
+                  <tr>
+                     <th style="min-width:10%;">Name</th>
+                     <th>Description</th>
+                     <th>Where to set value</th>
+                  </tr>
+               </thead>
+               <tbody>
+                  <tr>
+                     <th scope="row" class="param">project-id</th>
+                     <td>The unique identifier of the project to be deleted.</td>
+                     <td>URL</td>
+                  </tr>
+               </tbody>
+            </table>
+         </section>
+         <section aria-labelledby="section_list-registered-view-packages">
+            <h3 id="section_list-registered-view-packages">List registered view packages</h3>
+            <p><code class="endpoint">GET /tapas-xq/view-packages</code></p>
+            <p>Retrieve the XML registry of all view packages currently available in TAPAS-xq.</p>
+            <p>This endpoint returns the XML registry of view packages, with status code 200.</p>
+         </section>
+         <section aria-labelledby="section_update-registered-view-packages">
+            <h3 id="section_update-registered-view-packages">Update registered view packages</h3>
+            <p><code class="endpoint">POST /tapas-xq/view-packages</code></p>
+            <p>Update the view packages database using the latest commits from the GitHub repository.
+               Then, update 
+               the view package registry.</p>
+            <p><strong>Important:</strong> This endpoint can only be accessed by BaseX accounts with administrator
+               permissions.</p>
+            <p>This endpoint returns a short confirmation in XML that the view package repository and database has been
+               updated,
+               with status code 201. The view package registry will be re-generated after 500 milliseconds.</p>
+         </section>
+         <section aria-labelledby="section_get-view-package-configuration">
+            <h3 id="section_get-view-package-configuration">Get view package configuration</h3>
+            <p><code class="endpoint">GET /tapas-xq/view-packages/<strong class="param">package-id</strong></code></p>
+            <p>Retrieve the configuration file for a given view package.</p>
+            <p>This endpoint returns the XML configuration file of the view package with status code 200. If the requested
+               
+               identifier does not match a view package registered with TAPAS-xq, the response will
+               have a status 
+               code of 400.</p>
+            <table class="function-params">
+               <caption>Request settings</caption>
+               <thead>
+                  <tr>
+                     <th style="min-width:10%;">Name</th>
+                     <th>Description</th>
+                     <th>Where to set value</th>
+                  </tr>
+               </thead>
+               <tbody>
+                  <tr>
+                     <th scope="row" class="param">package-id</th>
+                     <td>The identifier of the view package.</td>
+                     <td>URL</td>
+                  </tr>
+               </tbody>
+            </table>
+         </section>
+      </main>
+   </body>
+</html>

--- a/API.md
+++ b/API.md
@@ -1,5 +1,5 @@
 
-This documentation was generated from its <a href="https://github.com/NEU-DSG/tapas-xq/blob/migrate/to-basex-10/modules/tapas-api.xql">source code</a> on May 3rd, 2024, 3:54 p.m. GMT-04:00.
+This documentation was generated from its <a href="https://github.com/NEU-DSG/tapas-xq/blob/develop/modules/tapas-api.xql">source code</a> on June 25th, 2024, 12:06 p.m. GMT-04:00.
 
 # API documentation
 
@@ -201,6 +201,9 @@ This endpoint returns the XML registry of view packages, with status code 200.
 
 Update the view packages database using the latest commits from the GitHub repository. Then, update 
 the view package registry.
+
+<strong>Important:</strong> This endpoint can only be accessed by BaseX accounts with administrator
+permissions.
 
 This endpoint returns a short confirmation in XML that the view package repository and database has been updated,
 with status code 201. The view package registry will be re-generated after 500 milliseconds.

--- a/README.md
+++ b/README.md
@@ -103,9 +103,10 @@ If using the BaseX WAR, place the web archive in the `webapps` directory of [Apa
 
 To make full use of TAPAS-xq, you will need to configure BaseX further:
 
-- Set up credentials for the BaseX "admin" account
-- Enable XSLT 3.0 transformation
-- Require authentication through BaseX
+- [Set up credentials for the BaseX "admin" account](#set-up-credentials-for-the-basex-admin-account)
+- [Enable XSLT 3.0 transformation](#enable-xslt-30)
+- [Require authentication through BaseX](#require-authentication)
+- [Deploy TAPAS-xq](#deploying-tapas-xq)
 
 
 #### Set up credentials for the BaseX "admin" account

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ BaseX will allow XSL 3.0 transformations if it finds a [Saxon processor](https:/
 
 To set this up, [download the latest Saxon HE package](https://github.com/Saxonica/Saxon-HE/releases) and unpack it. Place the extracted directory into `BASEX/lib/custom` (ZIP installation) or `BASEX/lib` (WAR installation). You'll need to restart BaseX so that it registers the library.
 
-To make sure you've installed Saxon HE correctly, navigate to `BASE-URL/dba/queries` in your browser, and run `xslt:processor()`. You should see the result "Saxon HE", not "Java".
+To make sure you've installed Saxon HE correctly, navigate to `BASE-URL/dba/editor` in your browser, and run `xslt:processor()`. You should see the result "Saxon HE", not "Java".
 
 
 #### Require authentication
@@ -216,7 +216,7 @@ curl -X GET -u admin "http://localhost:8088/BaseX107/rest?run=tapas-xq/modules/i
 
 The [TAPAS-xq installation script](modules/installation.bxs) sets up the `tapas-data` and `tapas-view-packages` databases for you. It also sets up the "tapas" user (whose default password is "tapas"). The "tapas" user is the primary user of the TAPAS-xq; it is the account through which the TAPAS Rails service interacts with the TAPAS-xq databases.
 
-**Note:** Earlier versions of TAPAS-xq were installed by generating an EXPath application "XAR file". This method is no longer useful for installation, since BaseX doesn't register API endpoints when XQuery modules are installed from XARs.
+**Note:** Earlier versions of TAPAS-xq were installed by generating an [EXPath application "XAR file"](http://expath.org/spec/pkg#concepts). This method is no longer useful for installation, since BaseX doesn't register API endpoints when XQuery modules are installed from XARs. We have retained the [EXPath package descriptor](./expath-pkg.xml), which is still helpful for tracking versions and dependencies.
 
 
 ***

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ For local development work, you may wish to use the [Docker instructions](docker
 
 ### Setting up BaseX
 
-TAPAS-xq is designed to run in [BaseX](https://basex.org/), an open source XML database engine. [Download either the ZIP or WAR package](https://basex.org/download/) of BaseX at major semantic version 10.
+TAPAS-xq is designed to run in [BaseX](https://basex.org/), an open source XML database engine. [Download either the ZIP or WAR package](https://basex.org/download/) of BaseX at major semantic version 10 or 11.
 
 If using the BaseX ZIP, unpack the archive and place the directory wherever you'd like.
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,11 +14,11 @@ WORKDIR /var/cache/basex
 
 # Download BaseX
 RUN --mount=type=cache,target=/var/cache/basex \
-    wget https://files.basex.org/releases/11.0/BaseX110.zip
+    wget https://files.basex.org/releases/11.1/BaseX111.zip
 
 # Unpack BaseX
 RUN --mount=type=cache,target=/var/cache/basex \
-    unzip BaseX110.zip -d /opt
+    unzip BaseX111.zip -d /opt
 
 # Download the Saxon HE processor
 WORKDIR /var/cache/saxonhe

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -49,4 +49,4 @@ WORKDIR /opt/basex
 RUN bin/basex webapp/tapas-xq/modules/installation.bxs
 
 # When the Docker container starts up, run BaseX
-CMD /opt/basex/bin/basexhttp
+CMD /opt/basex/bin/basexhttp -h8080

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,9 +6,6 @@ RUN --mount=type=cache,target=/var/cache/apt \
     apt-get update && \
     apt-get install -y wget unzip git curl
 
-# Create a folder for BaseX
-#RUN mkdir /opt/basex
-
 # Set up the cache directory for zipped resources
 WORKDIR /var/cache
 RUN mkdir basex
@@ -17,11 +14,11 @@ WORKDIR /var/cache/basex
 
 # Download BaseX
 RUN --mount=type=cache,target=/var/cache/basex \
-    wget https://files.basex.org/releases/10.7/BaseX107.zip
+    wget https://files.basex.org/releases/11.0/BaseX110.zip
 
 # Unpack BaseX
 RUN --mount=type=cache,target=/var/cache/basex \
-    unzip BaseX107.zip -d /opt
+    unzip BaseX110.zip -d /opt
 
 # Download the Saxon HE processor
 WORKDIR /var/cache/saxonhe

--- a/expath-pkg.xml
+++ b/expath-pkg.xml
@@ -1,9 +1,9 @@
 <package xmlns="http://expath.org/ns/pkg"
     name="http://www.tapasproject.org/apps/tapas-xq"
-    abbrev="tapas-xq" version="1.0.0" spec="1.0">
+    abbrev="tapas-xq" version="1.1.0" spec="1.0">
   <title>TAPAS-xq</title>
   
-  <dependency processor="basex" semver-min="10.0" semver-max="10.7"/>
+  <dependency processor="basex" semver-min="10.0" semver-max="11.0"/>
   
   <xquery>
     <namespace>http://tapasproject.org/tapas-xq/view-pkgs</namespace>

--- a/expath-pkg.xml
+++ b/expath-pkg.xml
@@ -3,7 +3,7 @@
     abbrev="tapas-xq" version="1.1.0" spec="1.0">
   <title>TAPAS-xq</title>
   
-  <dependency processor="basex" semver-min="10.0" semver-max="11.0"/>
+  <dependency processor="basex" semver-min="10.0" semver-max="11.1"/>
   
   <xquery>
     <namespace>http://tapasproject.org/tapas-xq/view-pkgs</namespace>

--- a/modules/tapas-api.xql
+++ b/modules/tapas-api.xql
@@ -106,8 +106,8 @@ xquery version "3.1";
       let $params := map {
           'html-title': "TAPAS-xq API",
           'source-code-url':
-            "https://github.com/NEU-DSG/tapas-xq/blob/migrate/to-basex-10/modules/tapas-api.xql"
-        }(: TODO: update link! :)
+            "https://github.com/NEU-DSG/tapas-xq/blob/develop/modules/tapas-api.xql"
+        }
       return
         if ( $formatAsMarkdown ) then
           xslt:transform-text($xqDocXML, doc('../resources/xqdoc-to-markdown.xsl'), $params)
@@ -571,6 +571,9 @@ xquery version "3.1";
     Update the view packages database using the latest commits from the GitHub repository. Then, update 
     the view package registry.
     
+    <strong>Important:</strong> This endpoint can only be accessed by BaseX accounts with administrator
+    permissions.
+    
     @return a short confirmation in XML that the view package repository and database has been updated,
       with status code 201. The view package registry will be re-generated after 500 milliseconds.
    :)
@@ -582,10 +585,21 @@ xquery version "3.1";
     %output:media-type("application/xml")
   function tap:update-registered-view-packages() {
     let $successCode := 201
-    return (
-        dpkg:update-database-to-latest(),
-        update:output(tap:plan-response(201, ()))
-      )
+    return 
+      (: Attempt to update the view package database. If the current user does not have permission to 
+        run `job:eval()`, or some other error occurs, return the error. :)
+      try {
+        (
+          dpkg:update-database-to-latest(),
+          update:output(tap:plan-response(201, ()))
+        )
+      } catch Q{http://basex.org}permission {
+        let $err := tgen:set-error(401, "This endpoint is limited to administrator accounts only.")
+        return update:output(tap:plan-response(201, $err))
+      } catch * {
+        let $err := tgen:set-error(500, $err:code||' '||$err:value)
+        return update:output(tap:plan-response(201, $err))
+      }
   };
   
   

--- a/modules/tapas-api.xql
+++ b/modules/tapas-api.xql
@@ -102,6 +102,10 @@ xquery version "3.1";
     let $successCode := 200
     let $formatAsMarkdown := lower-case($format) eq 'markdown'
     let $xqDocXML := inspect:xqdoc('tapas-api.xql')
+    (: Test for a bug in BaseX 11.0 where every <xqdoc:description> contains only digits, not readable 
+      text. :)
+    let $useFallback := 
+      $xqDocXML//Q{http://www.xqdoc.org/1.0}description[1][not(contains(., ' '))]
     let $outputDocs := 
       let $params := map {
           'html-title': "TAPAS-xq API",
@@ -109,11 +113,23 @@ xquery version "3.1";
             "https://github.com/NEU-DSG/tapas-xq/blob/develop/modules/tapas-api.xql"
         }
       return
-        if ( $formatAsMarkdown ) then
+        (: If the request is for Markdown and the auto-processed descriptions are unusable, respond with 
+          the contents of the Markdown file previously saved to the TAPAS-xq repository. :)
+        if ( $formatAsMarkdown and $useFallback ) then
+          unparsed-text("../API.md")
+        (: If the request is for Markdown, transform the automatically processed XQDoc format into 
+          Markdown documentation. :)
+        else if ( $formatAsMarkdown ) then
           xslt:transform-text($xqDocXML, doc('../resources/xqdoc-to-markdown.xsl'), $params)
+        (: If the request is for HTML and the auto-processed descriptions are unusable, respond with the 
+          (serialized) HTML documentation previously saved to the TAPAS-xq repository. :)
+        else if ( $useFallback ) then
+          doc("../API.html") => serialize()
+        (: If the request is for HTML, transform the automatically processed XQDoc format into HTML, 
+          then serialize it. :)
         else
           xslt:transform($xqDocXML, doc('../resources/xqdoc-to-api-docs.xsl'), $params)
-          => serialize()
+            => serialize()
     let $mediaTypeHeader :=
       let $contentType := if ( $formatAsMarkdown ) then 'markdown' else 'html'
       return

--- a/modules/view-packages.xql
+++ b/modules/view-packages.xql
@@ -202,6 +202,7 @@ xquery version "3.1";
       (: Start the compilation process in 500 ms. Cache the result temporarily, which will make it 
         easier to debug any errors. :)
       let $jobOptions := map { 'start': 'PT0.5S', 'cache': true() }
+      (: Note: job:eval() requires admin permissions to run! :)
       return job:eval($makeRegistry, (), $jobOptions)
     return dpkg:update-database-from-filesystem()
   };


### PR DESCRIPTION
Resolves #25.

It turns out that the upgrade to BaseX v11 is pretty seamless! All endpoints have been tested for deprecations. The configuration settings and the BaseX-specific functions can remain unchanged.

This pull request does include slight improvements to the documentation and code:

- The BaseX "Queries" tab in the Database Administration app has been renamed to "Editor", reflecting the v11 change.
- Additional context has been added in the Readme for "EXPath application XARs", and why we continue to use the package descriptor.
- The "Update view packages" endpoint is now clearer in its response when the user doesn't have permission to make the update (admin permissions are required). The documentation has been updated to stress this point.
- The GitHub URL to `tapas-api.xql` has been updated to the `develop` branch.

Unfortunately, BaseX v11.0 includes what appears to be a bug in the `inspect:xqdoc()` function: Each `<xqdoc:description>` now contains a very large number rather than the main content of the XQDoc comment. This PR will remain in draft form until I can determine if there's a workaround, or if we should wait for v11.1.

To complete this PR:

- [x] Test all API endpoints
- [x] Restore the readability of the "Get documentation" endpoint
- [x] Update TAPAS-xq version
- [x] Update which BaseX versions can be used
- [x] Use BaseX v11 to construct Docker image and container
