### PR TITLE
Upgrade to BaseX v12.2 and update API docs

### DIFF
--- a/API.html
+++ b/API.html
@@ -37,7 +37,7 @@
    </head>
    <body>
       <aside>
-         <p>This documentation was generated from its <a href="https://github.com/NEU-DSG/tapas-xq/blob/develop/modules/tapas-api.xql">source code</a> on March 17th, 2026, 12:22 p.m. GMT-04:00.</p>
+         <p>This documentation was generated from its <a href="https://github.com/NEU-DSG/tapas-xq/blob/develop/modules/tapas-api.xql">source code</a> on March 17th, 2026, 12:41 p.m. GMT-04:00.</p>
       </aside>
       <main>
          <h1>TAPAS-xq API documentation</h1>
@@ -57,9 +57,7 @@
             credentials for a BaseX user with write access to the TAPAS databases. If a request
             doesn’t meet this
             criteria, a response with an HTTP status code 401 will be returned.</p>
-         <p>
-            <h2 id="tei-viability-testing">TEI viability testing</h2>
-         </p>
+         <h2 id="tei-viability-testing">TEI viability testing</h2>
          <p>If an endpoint accepts TEI XML in a request, TAPAS-xq must receive a single, <a href="https://wwp.northeastern.edu/outreach/seminars/_current/presentations/xml_intro/xml_newIntro_tutorial_13.xhtml">well-formed</a> XML file, with <code>&lt;TEI xmlns="http://www.tei-c.org/ns/1.0"&gt;</code> 
             (<a href="https://en.wikipedia.org/wiki/XML_namespace#Namespace_declaration">or an equivalent</a>) as 
             the outermost element, and exactly one <code>&lt;teiHeader&gt;</code>. No arbitrary Javascript is 

--- a/API.html
+++ b/API.html
@@ -37,7 +37,7 @@
    </head>
    <body>
       <aside>
-         <p>This documentation was generated from its <a href="https://github.com/NEU-DSG/tapas-xq/blob/develop/modules/tapas-api.xql">source code</a> on March 10th, 2026, 2:20 p.m. GMT-04:00.</p>
+         <p>This documentation was generated from its <a href="https://github.com/NEU-DSG/tapas-xq/blob/develop/modules/tapas-api.xql">source code</a> on March 17th, 2026, 12:22 p.m. GMT-04:00.</p>
       </aside>
       <main>
          <h1>TAPAS-xq API documentation</h1>
@@ -100,7 +100,7 @@
          <p>When a test failure occurs, HTTP status code 422 will be returned. The response body
             will contain a 
             description of identified problems.</p>
-         <h2 id="all-endpoints">Request endpoints</h2>
+         <h2 id="request-endpoints">Request endpoints</h2>
          <section aria-labelledby="section_get-documentation">
             <h3 id="section_get-documentation">Get documentation</h3>
             <p><code class="endpoint">GET /tapas-xq/api</code></p>

--- a/API.html
+++ b/API.html
@@ -1,7 +1,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en">
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
-      <title>TAPAS-xq API</title>
+      <title>TAPAS-xq API documentation</title>
       <style>
           body {
             font-family: Verdana, Helvetica, Arial, sans-serif;
@@ -37,10 +37,10 @@
    </head>
    <body>
       <aside>
-         <p>This documentation was generated from its <a href="https://github.com/NEU-DSG/tapas-xq/blob/develop/modules/tapas-api.xql">source code</a> on June 27th, 2024, 2:53 p.m. GMT-04:00.</p>
+         <p>This documentation was generated from its <a href="https://github.com/NEU-DSG/tapas-xq/blob/develop/modules/tapas-api.xql">source code</a> on March 10th, 2026, 1:18 p.m. GMT-04:00.</p>
       </aside>
       <main>
-         <h1>API documentation</h1>
+         <h1>TAPAS-xq API documentation</h1>
          <p>This is the API for TAPAS-xq, the XML database component of TAPAS. TAPAS-xq stores
             TEI documents, 
             indexes them, and generates derivatives such as MODS metadata and reading interface
@@ -57,11 +57,58 @@
             credentials for a BaseX user with write access to the TAPAS databases. If a request
             doesn’t meet this
             criteria, a response with an HTTP status code 401 will be returned.</p>
+         <p>
+            <h2>TEI viability testing</h2>
+         </p>
+         <p>If an endpoint accepts TEI XML in a request, TAPAS-xq must receive a single, <a href="https://wwp.northeastern.edu/outreach/seminars/_current/presentations/xml_intro/xml_newIntro_tutorial_13.xhtml">well-formed</a> XML file, with <code>&lt;TEI xmlns="http://www.tei-c.org/ns/1.0"&gt;</code> 
+            (<a href="https://en.wikipedia.org/wiki/XML_namespace#Namespace_declaration">or an equivalent</a>) as 
+            the outermost element, and exactly one <code>&lt;teiHeader&gt;</code>. No arbitrary Javascript is 
+            allowed. TAPAS-xq does not, however, validate the file against a full TEI schema.
+            This allows TAPAS 
+            users to upload files that adhere to arbitrary (modern) TEI versions, or even their
+            own custom schemas.</p>
+         <p>TAPAS-xq will run minimal validation processes on a request’s file parameter before
+            doing anything 
+            else. Processing will halt for any of the following cases:</p>
+         <p>
+            <ul>
+               
+               <li>Multiple files are identified</li>
+               
+               <li>The file is an unparsable binary file</li>
+               
+               <li>The file cannot be parsed as XML (it may be ill-formed)</li>
+               
+               <li>The file is parsable XML but one or more of the following is true:
+                  
+                  <ul>
+                     
+                     <li>The outermost element is not in the TEI namespace 
+                        (<code>http://www.tei-c.org/ns/1.0</code>)</li>
+                     
+                     <li>The outermost element’s name is not <code>TEI</code></li>
+                     
+                     <li>There is no <code>teiHeader</code> element</li>
+                     
+                     <li>There are multiple <code>teiHeader</code> elements</li>
+                     
+                     <li>An element named <code>script</code> is found in any namespace</li>
+                     </ul>
+                  </li>
+               </ul>
+         </p>
+         <p>When a test failure occurs, HTTP status code 422 will be returned. The response body
+            will contain a 
+            description of identified problems.</p>
          <h2 id="all-endpoints">Request endpoints</h2>
          <section aria-labelledby="section_get-documentation">
             <h3 id="section_get-documentation">Get documentation</h3>
             <p><code class="endpoint">GET /tapas-xq/api</code></p>
-            <p>Generate documentation for the TAPAS-xq API, in XHTML or Markdown.</p>
+            <p>Generate documentation for the TAPAS-xq API, in XHTML or Markdown. If the user has
+               administrator 
+               privileges, this documentation is generated dynamically from the RESTXQ code. Otherwise,
+               a cached 
+               HTML or Markdown file is used.</p>
             <p>This endpoint returns a representation of the API documentation, with status code 200.</p>
             <table class="function-params">
                <caption>Request settings</caption>
@@ -76,7 +123,7 @@
                   <tr>
                      <th scope="row" class="param">format</th>
                      <td>The formatting method to use when producing documentation. Valid options are 
-                        "markdown" or "html". The default is to return XHTML.</td>
+                        "markdown" or "html". The default is to return HTML, in XHTML format.</td>
                      <td>query parameter</td>
                   </tr>
                </tbody>
@@ -94,12 +141,15 @@
                is initially 
                created, this endpoint alone will suffice to generate everything needed by TAPAS-xq
                and Rails.</p>
-            <p>This endpoint returns the MODS record derived from the TEI file, with HTTP status code 201. Any problems
-               with the 
-               TEI file will result in a response code of 500. If the MODS file could not be generated
-               due to 
-               transformation issues, the TEI and TFE files will still be stored despite the response
-               error code.</p>
+            <p>This endpoint returns the MODS record derived from the TEI file, with HTTP status code 201.</p>
+            <p>If the provided file is not viable TEI, processing will halt with HTTP status code
+               422. See the 
+               “TEI viability testing” section above for more information.</p>
+            <p>If the MODS file could not be generated because of a problem with the XSLT stylesheet,
+               an HTTP 
+               status code 500 will be returned. If necessary, the TAPAS-xq maintainer should be
+               alerted so they 
+               can fix the problem. The TEI and TFE files will be stored regardless.</p>
             <table class="function-params">
                <caption>Request settings</caption>
                <thead>
@@ -168,6 +218,9 @@
             <p>Store a TEI document.</p>
             <p>This endpoint returns a URL path for accessing the stored TEI file through the TAPAS-xq API, with status
                code 201.</p>
+            <p>If the provided file is not viable TEI, processing will halt with HTTP status code
+               422. See the 
+               “TEI viability testing” section above for more information.</p>
             <table class="function-params">
                <caption>Request settings</caption>
                <thead>
@@ -207,8 +260,8 @@
             <p>The TEI core file must be stored <em>before</em> any of its derivatives.</p>
             <p>This endpoint returns the MODS record derived from the TEI file, with status code 201. If no TEI document
                is 
-               associated with the given <code class="param">doc-id</code>, the response will have a status code 
-               of 500.</p>
+               associated with the given <code class="param">doc-id</code>, or if something went wrong with the 
+               MODS transformation, the response will have a status code of 500.</p>
             <table class="function-params">
                <caption>Request settings</caption>
                <thead>
@@ -315,6 +368,9 @@
                selected. Check 
                the view package’s configuration file for additional parameters.</p>
             <p>This endpoint returns generated XHTML with status code 200.</p>
+            <p>If the provided file is not viable TEI, processing will halt with HTTP status code
+               422. See the 
+               “TEI viability testing” section above for more information.</p>
             <table class="function-params">
                <caption>Request settings</caption>
                <thead>
@@ -334,10 +390,10 @@
                   </tr>
                   <tr>
                      <th scope="row" class="param">file</th>
-                     <td>A TEI-encoded XML document. If, in the future, a view package makes use of a different
-                        
-                        input source (such as a TAPAS collection or a project), the file parameter may become
-                        optional.</td>
+                     <td>A TEI-encoded XML document. The file parameter may become optional in the future,
+                        if a 
+                        view package makes use of a different input source (such as a TAPAS collection or
+                        a project).</td>
                      <td>form parameter</td>
                   </tr>
                </tbody>

--- a/API.html
+++ b/API.html
@@ -37,7 +37,7 @@
    </head>
    <body>
       <aside>
-         <p>This documentation was generated from its <a href="https://github.com/NEU-DSG/tapas-xq/blob/develop/modules/tapas-api.xql">source code</a> on March 17th, 2026, 12:49 p.m. GMT-04:00.</p>
+         <p>This documentation was generated from its <a href="https://github.com/NEU-DSG/tapas-xq/blob/develop/modules/tapas-api.xql">source code</a> on March 26th, 2026, 11:42 a.m. GMT-04:00.</p>
       </aside>
       <main>
          <h1>TAPAS-xq API documentation</h1>
@@ -255,8 +255,8 @@
                request. Store the MODS in the database alongside its core file TEI.</p>
             <p>The TEI core file must be stored <em>before</em> any of its derivatives.</p>
             <p>This endpoint returns the MODS record derived from the TEI file, with status code 201.</p>
-            <p>If no TEI document is associated with the given <code class="param">doc-id</code>, a response with 
-               HTTP status code 404 will be returned.</p>
+            <p>If no TEI document is associated with the given <code class="param">project-id</code> and 
+               <code class="param">doc-id</code>, a response with HTTP status code 404 will be returned.</p>
             <p>If something went wrong with the MODS transformation, the response will have a status
                code of 500. 
                If necessary, the TAPAS-xq maintainer should be alerted so they can fix the problem.</p>
@@ -313,8 +313,8 @@
             <p>The TEI core file must be stored <em>before</em> any of its derivatives.</p>
             <p>This endpoint returns a URL path for reading the new TFE file through the TAPAS-xq API, with status code
                201.</p>
-            <p>If no TEI document is associated with the given <code class="param">doc-id</code>, a response with 
-               HTTP status code 404 will be returned.</p>
+            <p>If no TEI document is associated with the given <code class="param">project-id</code> and 
+               <code class="param">doc-id</code>, a response with HTTP status code 404 will be returned.</p>
             <table class="function-params">
                <caption>Request settings</caption>
                <thead>
@@ -402,8 +402,8 @@
             <p><code class="endpoint">GET /tapas-xq/<strong class="param">project-id</strong>/<strong class="param">doc-id</strong>/tei</code></p>
             <p>Retrieve a TEI file stored in the XML database.</p>
             <p>This endpoint returns a copy of the TEI file, with status code 200.</p>
-            <p>If no TEI document is associated with the given <code class="param">doc-id</code>, a response with 
-               HTTP status code 404 will be returned.</p>
+            <p>If no TEI document is associated with the given <code class="param">project-id</code> and 
+               <code class="param">doc-id</code>, a response with HTTP status code 404 will be returned.</p>
             <p>If the file is marked as private in the contextual metadata (TFE file), only users
                with write 
                access to the database will be able to access the file. An attempt at unauthorized
@@ -437,8 +437,8 @@
             <p><code class="endpoint">GET /tapas-xq/<strong class="param">project-id</strong>/<strong class="param">doc-id</strong>/mods</code></p>
             <p>Retrieve a MODS file associated with a given core file identifier.</p>
             <p>This endpoint returns a copy of the MODS metadata, with status code 200.</p>
-            <p>If no TEI document is associated with the given <code class="param">doc-id</code>, a response with 
-               HTTP status code 404 will be returned.</p>
+            <p>If no TEI document is associated with the given <code class="param">project-id</code> and 
+               <code class="param">doc-id</code>, a response with HTTP status code 404 will be returned.</p>
             <p>If the file is marked as private in the contextual metadata (TFE file), only users
                with write 
                access to the database will be able to access the file. An attempt at unauthorized
@@ -473,8 +473,8 @@
             <p>Retrieve a TAPAS-friendly environment (TFE) file associated with a given core file
                identifier.</p>
             <p>This endpoint returns a copy of the TFE metadata, with status code 200.</p>
-            <p>If no TEI document is associated with the given <code class="param">doc-id</code>, a response with 
-               HTTP status code 404 will be returned.</p>
+            <p>If no TEI document is associated with the given <code class="param">project-id</code> and 
+               <code class="param">doc-id</code>, a response with HTTP status code 404 will be returned.</p>
             <p>If the file is marked as private in the contextual metadata (TFE file), only users
                with write 
                access to the database will be able to access the file. An attempt at unauthorized
@@ -510,8 +510,8 @@
                TEI file, 
                MODS metadata, and TAPAS-friendly environment record.</p>
             <p>This endpoint returns a short confirmation in XML that the resources will be deleted, with status code 202.</p>
-            <p>If no TEI document is associated with the given <code class="param">doc-id</code>, a response with 
-               HTTP status code 404 will be returned.</p>
+            <p>If no TEI document is associated with the given <code class="param">project-id</code> and 
+               <code class="param">doc-id</code>, a response with HTTP status code 404 will be returned.</p>
             <table class="function-params">
                <caption>Request settings</caption>
                <thead>
@@ -540,7 +540,7 @@
             <p><code class="endpoint">DELETE /tapas-xq/<strong class="param">project-id</strong></code></p>
             <p>Completely remove all database records associated with the given TAPAS project.</p>
             <p>This endpoint returns a short confirmation in XML that the resources will be deleted, with status code 202.</p>
-            <p>If no TEI document is associated with the given <code class="param">doc-id</code>, a response with 
+            <p>If no project is associated with the given <code class="param">project-id</code>, a response with 
                HTTP status code 404 will be returned.</p>
             <table class="function-params">
                <caption>Request settings</caption>

--- a/API.html
+++ b/API.html
@@ -37,7 +37,7 @@
    </head>
    <body>
       <aside>
-         <p>This documentation was generated from its <a href="https://github.com/NEU-DSG/tapas-xq/blob/develop/modules/tapas-api.xql">source code</a> on March 10th, 2026, 1:36 p.m. GMT-04:00.</p>
+         <p>This documentation was generated from its <a href="https://github.com/NEU-DSG/tapas-xq/blob/develop/modules/tapas-api.xql">source code</a> on March 10th, 2026, 1:54 p.m. GMT-04:00.</p>
       </aside>
       <main>
          <h1>TAPAS-xq API documentation</h1>

--- a/API.html
+++ b/API.html
@@ -37,7 +37,7 @@
    </head>
    <body>
       <aside>
-         <p>This documentation was generated from its <a href="https://github.com/NEU-DSG/tapas-xq/blob/develop/modules/tapas-api.xql">source code</a> on March 17th, 2026, 12:41 p.m. GMT-04:00.</p>
+         <p>This documentation was generated from its <a href="https://github.com/NEU-DSG/tapas-xq/blob/develop/modules/tapas-api.xql">source code</a> on March 17th, 2026, 12:49 p.m. GMT-04:00.</p>
       </aside>
       <main>
          <h1>TAPAS-xq API documentation</h1>
@@ -68,33 +68,31 @@
          <p>TAPAS-xq will run minimal validation processes on a request’s file parameter before
             doing anything 
             else. Processing will halt for any of the following cases:</p>
-         <p>
-            <ul>
+         <ul>
+            
+            <li>Multiple files are identified</li>
+            
+            <li>The file is an unparsable binary file</li>
+            
+            <li>The file cannot be parsed as XML (it may be ill-formed)</li>
+            
+            <li>The file is parsable XML but one or more of the following is true:
                
-               <li>Multiple files are identified</li>
-               
-               <li>The file is an unparsable binary file</li>
-               
-               <li>The file cannot be parsed as XML (it may be ill-formed)</li>
-               
-               <li>The file is parsable XML but one or more of the following is true:
+               <ul>
                   
-                  <ul>
-                     
-                     <li>The outermost element is not in the TEI namespace 
-                        (<code>http://www.tei-c.org/ns/1.0</code>)</li>
-                     
-                     <li>The outermost element’s name is not <code>TEI</code></li>
-                     
-                     <li>There is no <code>teiHeader</code> element</li>
-                     
-                     <li>There are multiple <code>teiHeader</code> elements</li>
-                     
-                     <li>An element named <code>script</code> is found in any namespace</li>
-                     </ul>
-                  </li>
-               </ul>
-         </p>
+                  <li>The outermost element is not in the TEI namespace 
+                     (<code>http://www.tei-c.org/ns/1.0</code>)</li>
+                  
+                  <li>The outermost element’s name is not <code>TEI</code></li>
+                  
+                  <li>There is no <code>teiHeader</code> element</li>
+                  
+                  <li>There are multiple <code>teiHeader</code> elements</li>
+                  
+                  <li>An element named <code>script</code> is found in any namespace</li>
+                  </ul>
+               </li>
+            </ul>
          <p>When a test failure occurs, HTTP status code 422 will be returned. The response body
             will contain a 
             description of identified problems.</p>

--- a/API.html
+++ b/API.html
@@ -37,7 +37,7 @@
    </head>
    <body>
       <aside>
-         <p>This documentation was generated from its <a href="https://github.com/NEU-DSG/tapas-xq/blob/develop/modules/tapas-api.xql">source code</a> on March 10th, 2026, 1:18 p.m. GMT-04:00.</p>
+         <p>This documentation was generated from its <a href="https://github.com/NEU-DSG/tapas-xq/blob/develop/modules/tapas-api.xql">source code</a> on March 10th, 2026, 1:36 p.m. GMT-04:00.</p>
       </aside>
       <main>
          <h1>TAPAS-xq API documentation</h1>
@@ -58,7 +58,7 @@
             doesn’t meet this
             criteria, a response with an HTTP status code 401 will be returned.</p>
          <p>
-            <h2>TEI viability testing</h2>
+            <h2 id="tei-viability-testing">TEI viability testing</h2>
          </p>
          <p>If an endpoint accepts TEI XML in a request, TAPAS-xq must receive a single, <a href="https://wwp.northeastern.edu/outreach/seminars/_current/presentations/xml_intro/xml_newIntro_tutorial_13.xhtml">well-formed</a> XML file, with <code>&lt;TEI xmlns="http://www.tei-c.org/ns/1.0"&gt;</code> 
             (<a href="https://en.wikipedia.org/wiki/XML_namespace#Namespace_declaration">or an equivalent</a>) as 
@@ -144,7 +144,7 @@
             <p>This endpoint returns the MODS record derived from the TEI file, with HTTP status code 201.</p>
             <p>If the provided file is not viable TEI, processing will halt with HTTP status code
                422. See the 
-               “TEI viability testing” section above for more information.</p>
+               <a href="#tei-viability-testing">“TEI viability testing”</a> section above for more information.</p>
             <p>If the MODS file could not be generated because of a problem with the XSLT stylesheet,
                an HTTP 
                status code 500 will be returned. If necessary, the TAPAS-xq maintainer should be
@@ -220,7 +220,7 @@
                code 201.</p>
             <p>If the provided file is not viable TEI, processing will halt with HTTP status code
                422. See the 
-               “TEI viability testing” section above for more information.</p>
+               <a href="#tei-viability-testing">“TEI viability testing”</a> section above for more information.</p>
             <table class="function-params">
                <caption>Request settings</caption>
                <thead>
@@ -370,7 +370,7 @@
             <p>This endpoint returns generated XHTML with status code 200.</p>
             <p>If the provided file is not viable TEI, processing will halt with HTTP status code
                422. See the 
-               “TEI viability testing” section above for more information.</p>
+               <a href="#tei-viability-testing">“TEI viability testing”</a> section above for more information.</p>
             <table class="function-params">
                <caption>Request settings</caption>
                <thead>

--- a/API.html
+++ b/API.html
@@ -37,7 +37,7 @@
    </head>
    <body>
       <aside>
-         <p>This documentation was generated from its <a href="https://github.com/NEU-DSG/tapas-xq/blob/develop/modules/tapas-api.xql">source code</a> on March 10th, 2026, 1:54 p.m. GMT-04:00.</p>
+         <p>This documentation was generated from its <a href="https://github.com/NEU-DSG/tapas-xq/blob/develop/modules/tapas-api.xql">source code</a> on March 10th, 2026, 2:20 p.m. GMT-04:00.</p>
       </aside>
       <main>
          <h1>TAPAS-xq API documentation</h1>
@@ -258,10 +258,12 @@
                provided in the 
                request. Store the MODS in the database alongside its core file TEI.</p>
             <p>The TEI core file must be stored <em>before</em> any of its derivatives.</p>
-            <p>This endpoint returns the MODS record derived from the TEI file, with status code 201. If no TEI document
-               is 
-               associated with the given <code class="param">doc-id</code>, or if something went wrong with the 
-               MODS transformation, the response will have a status code of 500.</p>
+            <p>This endpoint returns the MODS record derived from the TEI file, with status code 201.</p>
+            <p>If no TEI document is associated with the given <code class="param">doc-id</code>, a response with 
+               HTTP status code 404 will be returned.</p>
+            <p>If something went wrong with the MODS transformation, the response will have a status
+               code of 500. 
+               If necessary, the TAPAS-xq maintainer should be alerted so they can fix the problem.</p>
             <table class="function-params">
                <caption>Request settings</caption>
                <thead>
@@ -314,9 +316,9 @@
                project.</p>
             <p>The TEI core file must be stored <em>before</em> any of its derivatives.</p>
             <p>This endpoint returns a URL path for reading the new TFE file through the TAPAS-xq API, with status code
-               201. If 
-               no TEI document is associated with the given <code class="param">doc-id</code>, the response will 
-               have a status code of 500.</p>
+               201.</p>
+            <p>If no TEI document is associated with the given <code class="param">doc-id</code>, a response with 
+               HTTP status code 404 will be returned.</p>
             <table class="function-params">
                <caption>Request settings</caption>
                <thead>
@@ -403,9 +405,9 @@
             <h3 id="section_read-core-file">Read core file</h3>
             <p><code class="endpoint">GET /tapas-xq/<strong class="param">project-id</strong>/<strong class="param">doc-id</strong>/tei</code></p>
             <p>Retrieve a TEI file stored in the XML database.</p>
-            <p>This endpoint returns a copy of the TEI file, with status code 200. If the file does not exist, the response
-               will 
-               have a status code of 404.</p>
+            <p>This endpoint returns a copy of the TEI file, with status code 200.</p>
+            <p>If no TEI document is associated with the given <code class="param">doc-id</code>, a response with 
+               HTTP status code 404 will be returned.</p>
             <p>If the file is marked as private in the contextual metadata (TFE file), only users
                with write 
                access to the database will be able to access the file. An attempt at unauthorized
@@ -438,9 +440,9 @@
             <h3 id="section_read-core-file-object-description">Read core file object description</h3>
             <p><code class="endpoint">GET /tapas-xq/<strong class="param">project-id</strong>/<strong class="param">doc-id</strong>/mods</code></p>
             <p>Retrieve a MODS file associated with a given core file identifier.</p>
-            <p>This endpoint returns a copy of the MODS metadata, with status code 200. If the file does not exist, the
-               response 
-               will have a status code of 404.</p>
+            <p>This endpoint returns a copy of the MODS metadata, with status code 200.</p>
+            <p>If no TEI document is associated with the given <code class="param">doc-id</code>, a response with 
+               HTTP status code 404 will be returned.</p>
             <p>If the file is marked as private in the contextual metadata (TFE file), only users
                with write 
                access to the database will be able to access the file. An attempt at unauthorized
@@ -474,9 +476,9 @@
             <p><code class="endpoint">GET /tapas-xq/<strong class="param">project-id</strong>/<strong class="param">doc-id</strong>/tfe</code></p>
             <p>Retrieve a TAPAS-friendly environment (TFE) file associated with a given core file
                identifier.</p>
-            <p>This endpoint returns a copy of the TFE metadata, with status code 200. If the file does not exist, the
-               response 
-               will have a status code of 404.</p>
+            <p>This endpoint returns a copy of the TFE metadata, with status code 200.</p>
+            <p>If no TEI document is associated with the given <code class="param">doc-id</code>, a response with 
+               HTTP status code 404 will be returned.</p>
             <p>If the file is marked as private in the contextual metadata (TFE file), only users
                with write 
                access to the database will be able to access the file. An attempt at unauthorized
@@ -511,10 +513,9 @@
             <p>Completely remove all database records associated with a given TEI core file identifier:
                TEI file, 
                MODS metadata, and TAPAS-friendly environment record.</p>
-            <p>This endpoint returns a short confirmation in XML that the resources will be deleted, with status code 202.
-               If no 
-               TEI document is associated with the given identifier, the response will have a status
-               code of 500.</p>
+            <p>This endpoint returns a short confirmation in XML that the resources will be deleted, with status code 202.</p>
+            <p>If no TEI document is associated with the given <code class="param">doc-id</code>, a response with 
+               HTTP status code 404 will be returned.</p>
             <table class="function-params">
                <caption>Request settings</caption>
                <thead>
@@ -542,10 +543,9 @@
             <h3 id="section_delete-project-documents">Delete project documents</h3>
             <p><code class="endpoint">DELETE /tapas-xq/<strong class="param">project-id</strong></code></p>
             <p>Completely remove all database records associated with the given TAPAS project.</p>
-            <p>This endpoint returns a short confirmation in XML that the resources will be deleted, with status code 202.
-               If no 
-               TEI document is associated with the given identifier, the response will have a status
-               code of 500.</p>
+            <p>This endpoint returns a short confirmation in XML that the resources will be deleted, with status code 202.</p>
+            <p>If no TEI document is associated with the given <code class="param">doc-id</code>, a response with 
+               HTTP status code 404 will be returned.</p>
             <table class="function-params">
                <caption>Request settings</caption>
                <thead>
@@ -586,11 +586,10 @@
             <h3 id="section_get-view-package-configuration">Get view package configuration</h3>
             <p><code class="endpoint">GET /tapas-xq/view-packages/<strong class="param">package-id</strong></code></p>
             <p>Retrieve the configuration file for a given view package.</p>
-            <p>This endpoint returns the XML configuration file of the view package with status code 200. If the requested
-               
-               identifier does not match a view package registered with TAPAS-xq, the response will
-               have a status 
-               code of 400.</p>
+            <p>This endpoint returns the XML configuration file of the view package with status code 200. </p>
+            <p>If the requested identifier does not match a view package registered with TAPAS-xq,
+               the response 
+               will have an HTTP status code of 400.</p>
             <table class="function-params">
                <caption>Request settings</caption>
                <thead>

--- a/API.md
+++ b/API.md
@@ -1,7 +1,7 @@
 
-This documentation was generated from its <a href="https://github.com/NEU-DSG/tapas-xq/blob/develop/modules/tapas-api.xql">source code</a> on June 25th, 2024, 12:06 p.m. GMT-04:00.
+This documentation was generated from its <a href="https://github.com/NEU-DSG/tapas-xq/blob/develop/modules/tapas-api.xql">source code</a> on March 10th, 2026, 1:20 p.m. GMT-04:00.
 
-# API documentation
+# TAPAS-xq API documentation
 
 This is the API for TAPAS-xq, the XML database component of TAPAS. TAPAS-xq stores TEI documents, 
 indexes them, and generates derivatives such as MODS metadata and reading interface XHTML.
@@ -16,18 +16,52 @@ All POST and DELETE requests <strong>must</strong> include an Authentication hea
 credentials for a BaseX user with write access to the TAPAS databases. If a request doesn’t meet this
 criteria, a response with an HTTP status code 401 will be returned.
 
+
+## TEI viability testing
+
+
+If an endpoint accepts TEI XML in a request, TAPAS-xq must receive a single, <a href="https://wwp.northeastern.edu/outreach/seminars/_current/presentations/xml_intro/xml_newIntro_tutorial_13.xhtml">well-formed</a> XML file, with <code>&lt;TEI xmlns="http://www.tei-c.org/ns/1.0"&gt;</code> 
+(<a href="https://en.wikipedia.org/wiki/XML_namespace#Namespace_declaration">or an equivalent</a>) as 
+the outermost element, and exactly one <code>&lt;teiHeader&gt;</code>. No arbitrary Javascript is 
+allowed. TAPAS-xq does not, however, validate the file against a full TEI schema. This allows TAPAS 
+users to upload files that adhere to arbitrary (modern) TEI versions, or even their own custom schemas.
+
+TAPAS-xq will run minimal validation processes on a request’s file parameter before doing anything 
+else. Processing will halt for any of the following cases:
+
+<ul>
+<li>Multiple files are identified</li>
+<li>The file is an unparsable binary file</li>
+<li>The file cannot be parsed as XML (it may be ill-formed)</li>
+<li>The file is parsable XML but one or more of the following is true:
+<ul>
+<li>The outermost element is not in the TEI namespace 
+(<code>http://www.tei-c.org/ns/1.0</code>)</li>
+<li>The outermost element’s name is not <code>TEI</code></li>
+<li>There is no <code>teiHeader</code> element</li>
+<li>There are multiple <code>teiHeader</code> elements</li>
+<li>An element named <code>script</code> is found in any namespace</li>
+</ul>
+</li>
+</ul>
+
+When a test failure occurs, HTTP status code 422 will be returned. The response body will contain a 
+description of identified problems.
+
 ## Request endpoints
 
 ### Get documentation
 
 <code>GET /tapas-xq/api</code>
 
-Generate documentation for the TAPAS-xq API, in XHTML or Markdown.
+Generate documentation for the TAPAS-xq API, in XHTML or Markdown. If the user has administrator 
+privileges, this documentation is generated dynamically from the RESTXQ code. Otherwise, a cached 
+HTML or Markdown file is used.
 
 This endpoint returns a representation of the API documentation, with status code 200.
 
 <table><caption>Request settings</caption><thead><tr><th style="min-width:10%;">Name</th><th>Description</th><th>Where to set value</th></tr></thead><tbody><tr><th scope="row">format</th><td>The formatting method to use when producing documentation. Valid options are 
-"markdown" or "html". The default is to return XHTML.</td><td>query parameter</td></tr></tbody></table>
+"markdown" or "html". The default is to return HTML, in XHTML format.</td><td>query parameter</td></tr></tbody></table>
 
 ### Store core file and supplementals
 
@@ -40,9 +74,14 @@ This endpoint is a convenient wrapper for the “Store core file”, “Store co
 description”, and “Store core file contextual metadata” endpoints. When a core file is initially 
 created, this endpoint alone will suffice to generate everything needed by TAPAS-xq and Rails.
 
-This endpoint returns the MODS record derived from the TEI file, with HTTP status code 201. Any problems with the 
-TEI file will result in a response code of 500. If the MODS file could not be generated due to 
-transformation issues, the TEI and TFE files will still be stored despite the response error code.
+This endpoint returns the MODS record derived from the TEI file, with HTTP status code 201.
+
+If the provided file is not viable TEI, processing will halt with HTTP status code 422. See the 
+“TEI viability testing” section above for more information.
+
+If the MODS file could not be generated because of a problem with the XSLT stylesheet, an HTTP 
+status code 500 will be returned. If necessary, the TAPAS-xq maintainer should be alerted so they 
+can fix the problem. The TEI and TFE files will be stored regardless.
 
 <table><caption>Request settings</caption><thead><tr><th style="min-width:10%;">Name</th><th>Description</th><th>Where to set value</th></tr></thead><tbody><tr><th scope="row">project-id</th><td>The unique identifier of the project which owns the work.</td><td>URL</td></tr><tr><th scope="row">doc-id</th><td>A unique identifier for the document record attached to the original TEI document and 
 its derivatives.</td><td>URL</td></tr><tr><th scope="row">file</th><td>The TEI-encoded XML document to be stored.</td><td>form parameter</td></tr><tr><th scope="row">collections</th><td>Comma-separated list of collection identifiers with which the work should be 
@@ -60,6 +99,9 @@ Store a TEI document.
 
 This endpoint returns a URL path for accessing the stored TEI file through the TAPAS-xq API, with status code 201.
 
+If the provided file is not viable TEI, processing will halt with HTTP status code 422. See the 
+“TEI viability testing” section above for more information.
+
 <table><caption>Request settings</caption><thead><tr><th style="min-width:10%;">Name</th><th>Description</th><th>Where to set value</th></tr></thead><tbody><tr><th scope="row">project-id</th><td>The unique identifier of the project which owns the work.</td><td>URL</td></tr><tr><th scope="row">doc-id</th><td>A unique identifier for the document record attached to the original TEI document and 
 its derivatives (MODS, TFE).</td><td>URL</td></tr><tr><th scope="row">file</th><td>The TEI-encoded XML document to be stored.</td><td>form parameter</td></tr></tbody></table>
 
@@ -73,8 +115,8 @@ request. Store the MODS in the database alongside its core file TEI.
 The TEI core file must be stored <em>before</em> any of its derivatives.
 
 This endpoint returns the MODS record derived from the TEI file, with status code 201. If no TEI document is 
-associated with the given <code>doc-id</code>, the response will have a status code 
-of 500.
+associated with the given <code>doc-id</code>, or if something went wrong with the 
+MODS transformation, the response will have a status code of 500.
 
 <table><caption>Request settings</caption><thead><tr><th style="min-width:10%;">Name</th><th>Description</th><th>Where to set value</th></tr></thead><tbody><tr><th scope="row">project-id</th><td>The unique identifier of the project which owns the work.</td><td>URL</td></tr><tr><th scope="row">doc-id</th><td>A unique identifier for the document record attached to the original TEI document and 
 its derivatives.</td><td>URL</td></tr><tr><th scope="row">title</th><td>Optional. The work’s title as it should appear in TAPAS metadata.</td><td>form parameter</td></tr><tr><th scope="row">authors</th><td>Optional. A list of authors’ names as they should appear in TAPAS metadata, separated 
@@ -115,9 +157,12 @@ the view package’s configuration file for additional parameters.
 
 This endpoint returns generated XHTML with status code 200.
 
+If the provided file is not viable TEI, processing will halt with HTTP status code 422. See the 
+“TEI viability testing” section above for more information.
+
 <table><caption>Request settings</caption><thead><tr><th style="min-width:10%;">Name</th><th>Description</th><th>Where to set value</th></tr></thead><tbody><tr><th scope="row">type</th><td>A keyword representing the type of reader view to generate. Valid keywords can be found 
-by making a request to  the “List registered view packages” endpoint.</td><td>URL</td></tr><tr><th scope="row">file</th><td>A TEI-encoded XML document. If, in the future, a view package makes use of a different 
-input source (such as a TAPAS collection or a project), the file parameter may become optional.</td><td>form parameter</td></tr></tbody></table>
+by making a request to  the “List registered view packages” endpoint.</td><td>URL</td></tr><tr><th scope="row">file</th><td>A TEI-encoded XML document. The file parameter may become optional in the future, if a 
+view package makes use of a different input source (such as a TAPAS collection or a project).</td><td>form parameter</td></tr></tbody></table>
 
 ### Read core file
 

--- a/API.md
+++ b/API.md
@@ -1,5 +1,5 @@
 
-This documentation was generated from its <a href="https://github.com/NEU-DSG/tapas-xq/blob/develop/modules/tapas-api.xql">source code</a> on March 10th, 2026, 2:22 p.m. GMT-04:00.
+This documentation was generated from its <a href="https://github.com/NEU-DSG/tapas-xq/blob/develop/modules/tapas-api.xql">source code</a> on March 17th, 2026, 12:23 p.m. GMT-04:00.
 
 # TAPAS-xq API documentation
 
@@ -48,7 +48,7 @@ else. Processing will halt for any of the following cases:
 When a test failure occurs, HTTP status code 422 will be returned. The response body will contain a 
 description of identified problems.
 
-<h2 id="all-endpoints">Request endpoints</h2>
+<h2 id="request-endpoints">Request endpoints</h2>
 
 ### Get documentation
 

--- a/API.md
+++ b/API.md
@@ -1,5 +1,5 @@
 
-This documentation was generated from its <a href="https://github.com/NEU-DSG/tapas-xq/blob/develop/modules/tapas-api.xql">source code</a> on March 10th, 2026, 2:00 p.m. GMT-04:00.
+This documentation was generated from its <a href="https://github.com/NEU-DSG/tapas-xq/blob/develop/modules/tapas-api.xql">source code</a> on March 10th, 2026, 2:22 p.m. GMT-04:00.
 
 # TAPAS-xq API documentation
 
@@ -114,9 +114,13 @@ request. Store the MODS in the database alongside its core file TEI.
 
 The TEI core file must be stored <em>before</em> any of its derivatives.
 
-This endpoint returns the MODS record derived from the TEI file, with status code 201. If no TEI document is 
-associated with the given <code>doc-id</code>, or if something went wrong with the 
-MODS transformation, the response will have a status code of 500.
+This endpoint returns the MODS record derived from the TEI file, with status code 201.
+
+If no TEI document is associated with the given <code>doc-id</code>, a response with 
+HTTP status code 404 will be returned.
+
+If something went wrong with the MODS transformation, the response will have a status code of 500. 
+If necessary, the TAPAS-xq maintainer should be alerted so they can fix the problem.
 
 <table><caption>Request settings</caption><thead><tr><th style="min-width:10%;">Name</th><th>Description</th><th>Where to set value</th></tr></thead><tbody><tr><th scope="row">project-id</th><td>The unique identifier of the project which owns the work.</td><td>URL</td></tr><tr><th scope="row">doc-id</th><td>A unique identifier for the document record attached to the original TEI document and 
 its derivatives.</td><td>URL</td></tr><tr><th scope="row">title</th><td>Optional. The work’s title as it should appear in TAPAS metadata.</td><td>form parameter</td></tr><tr><th scope="row">authors</th><td>Optional. A list of authors’ names as they should appear in TAPAS metadata, separated 
@@ -132,9 +136,10 @@ containing useful information about the context of the TEI document, such as its
 
 The TEI core file must be stored <em>before</em> any of its derivatives.
 
-This endpoint returns a URL path for reading the new TFE file through the TAPAS-xq API, with status code 201. If 
-no TEI document is associated with the given <code>doc-id</code>, the response will 
-have a status code of 500.
+This endpoint returns a URL path for reading the new TFE file through the TAPAS-xq API, with status code 201.
+
+If no TEI document is associated with the given <code>doc-id</code>, a response with 
+HTTP status code 404 will be returned.
 
 <table><caption>Request settings</caption><thead><tr><th style="min-width:10%;">Name</th><th>Description</th><th>Where to set value</th></tr></thead><tbody><tr><th scope="row">project-id</th><td>The unique identifier of the project which owns the work.</td><td>URL</td></tr><tr><th scope="row">doc-id</th><td>A unique identifier for the document record attached to the original TEI document and 
 its derivatives.</td><td>URL</td></tr><tr><th scope="row">collections</th><td>Comma-separated list of collection identifiers with which the work should be 
@@ -170,8 +175,10 @@ view package makes use of a different input source (such as a TAPAS collection o
 
 Retrieve a TEI file stored in the XML database.
 
-This endpoint returns a copy of the TEI file, with status code 200. If the file does not exist, the response will 
-have a status code of 404.
+This endpoint returns a copy of the TEI file, with status code 200.
+
+If no TEI document is associated with the given <code>doc-id</code>, a response with 
+HTTP status code 404 will be returned.
 
 If the file is marked as private in the contextual metadata (TFE file), only users with write 
 access to the database will be able to access the file. An attempt at unauthorized access will 
@@ -185,8 +192,10 @@ yield a 403 status code and error.
 
 Retrieve a MODS file associated with a given core file identifier.
 
-This endpoint returns a copy of the MODS metadata, with status code 200. If the file does not exist, the response 
-will have a status code of 404.
+This endpoint returns a copy of the MODS metadata, with status code 200.
+
+If no TEI document is associated with the given <code>doc-id</code>, a response with 
+HTTP status code 404 will be returned.
 
 If the file is marked as private in the contextual metadata (TFE file), only users with write 
 access to the database will be able to access the file. An attempt at unauthorized access will 
@@ -200,8 +209,10 @@ yield a 403 status code and error.
 
 Retrieve a TAPAS-friendly environment (TFE) file associated with a given core file identifier.
 
-This endpoint returns a copy of the TFE metadata, with status code 200. If the file does not exist, the response 
-will have a status code of 404.
+This endpoint returns a copy of the TFE metadata, with status code 200.
+
+If no TEI document is associated with the given <code>doc-id</code>, a response with 
+HTTP status code 404 will be returned.
 
 If the file is marked as private in the contextual metadata (TFE file), only users with write 
 access to the database will be able to access the file. An attempt at unauthorized access will 
@@ -216,8 +227,10 @@ yield a 403 status code and error.
 Completely remove all database records associated with a given TEI core file identifier: TEI file, 
 MODS metadata, and TAPAS-friendly environment record.
 
-This endpoint returns a short confirmation in XML that the resources will be deleted, with status code 202. If no 
-TEI document is associated with the given identifier, the response will have a status code of 500.
+This endpoint returns a short confirmation in XML that the resources will be deleted, with status code 202.
+
+If no TEI document is associated with the given <code>doc-id</code>, a response with 
+HTTP status code 404 will be returned.
 
 <table><caption>Request settings</caption><thead><tr><th style="min-width:10%;">Name</th><th>Description</th><th>Where to set value</th></tr></thead><tbody><tr><th scope="row">project-id</th><td>The identifier of the project which owns the core file.</td><td>URL</td></tr><tr><th scope="row">doc-id</th><td>The identifier of the TEI core file.</td><td>URL</td></tr></tbody></table>
 
@@ -227,8 +240,10 @@ TEI document is associated with the given identifier, the response will have a s
 
 Completely remove all database records associated with the given TAPAS project.
 
-This endpoint returns a short confirmation in XML that the resources will be deleted, with status code 202. If no 
-TEI document is associated with the given identifier, the response will have a status code of 500.
+This endpoint returns a short confirmation in XML that the resources will be deleted, with status code 202.
+
+If no TEI document is associated with the given <code>doc-id</code>, a response with 
+HTTP status code 404 will be returned.
 
 <table><caption>Request settings</caption><thead><tr><th style="min-width:10%;">Name</th><th>Description</th><th>Where to set value</th></tr></thead><tbody><tr><th scope="row">project-id</th><td>The unique identifier of the project to be deleted.</td><td>URL</td></tr></tbody></table>
 
@@ -259,8 +274,9 @@ with status code 201. The view package registry will be re-generated after 500 m
 
 Retrieve the configuration file for a given view package.
 
-This endpoint returns the XML configuration file of the view package with status code 200. If the requested 
-identifier does not match a view package registered with TAPAS-xq, the response will have a status 
-code of 400.
+This endpoint returns the XML configuration file of the view package with status code 200. 
+
+If the requested identifier does not match a view package registered with TAPAS-xq, the response 
+will have an HTTP status code of 400.
 
 <table><caption>Request settings</caption><thead><tr><th style="min-width:10%;">Name</th><th>Description</th><th>Where to set value</th></tr></thead><tbody><tr><th scope="row">package-id</th><td>The identifier of the view package.</td><td>URL</td></tr></tbody></table>

--- a/API.md
+++ b/API.md
@@ -1,5 +1,5 @@
 
-This documentation was generated from its <a href="https://github.com/NEU-DSG/tapas-xq/blob/develop/modules/tapas-api.xql">source code</a> on March 10th, 2026, 1:37 p.m. GMT-04:00.
+This documentation was generated from its <a href="https://github.com/NEU-DSG/tapas-xq/blob/develop/modules/tapas-api.xql">source code</a> on March 10th, 2026, 2:00 p.m. GMT-04:00.
 
 # TAPAS-xq API documentation
 
@@ -17,7 +17,7 @@ credentials for a BaseX user with write access to the TAPAS databases. If a requ
 criteria, a response with an HTTP status code 401 will be returned.
 
 
-## TEI viability testing
+<h2 id="tei-viability-testing">TEI viability testing</h2>
 
 
 If an endpoint accepts TEI XML in a request, TAPAS-xq must receive a single, <a href="https://wwp.northeastern.edu/outreach/seminars/_current/presentations/xml_intro/xml_newIntro_tutorial_13.xhtml">well-formed</a> XML file, with <code>&lt;TEI xmlns="http://www.tei-c.org/ns/1.0"&gt;</code> 
@@ -48,7 +48,7 @@ else. Processing will halt for any of the following cases:
 When a test failure occurs, HTTP status code 422 will be returned. The response body will contain a 
 description of identified problems.
 
-## Request endpoints
+<h2 id="all-endpoints">Request endpoints</h2>
 
 ### Get documentation
 

--- a/API.md
+++ b/API.md
@@ -1,5 +1,5 @@
 
-This documentation was generated from its <a href="https://github.com/NEU-DSG/tapas-xq/blob/develop/modules/tapas-api.xql">source code</a> on March 10th, 2026, 1:20 p.m. GMT-04:00.
+This documentation was generated from its <a href="https://github.com/NEU-DSG/tapas-xq/blob/develop/modules/tapas-api.xql">source code</a> on March 10th, 2026, 1:37 p.m. GMT-04:00.
 
 # TAPAS-xq API documentation
 
@@ -77,7 +77,7 @@ created, this endpoint alone will suffice to generate everything needed by TAPAS
 This endpoint returns the MODS record derived from the TEI file, with HTTP status code 201.
 
 If the provided file is not viable TEI, processing will halt with HTTP status code 422. See the 
-“TEI viability testing” section above for more information.
+<a href="#tei-viability-testing">“TEI viability testing”</a> section above for more information.
 
 If the MODS file could not be generated because of a problem with the XSLT stylesheet, an HTTP 
 status code 500 will be returned. If necessary, the TAPAS-xq maintainer should be alerted so they 
@@ -100,7 +100,7 @@ Store a TEI document.
 This endpoint returns a URL path for accessing the stored TEI file through the TAPAS-xq API, with status code 201.
 
 If the provided file is not viable TEI, processing will halt with HTTP status code 422. See the 
-“TEI viability testing” section above for more information.
+<a href="#tei-viability-testing">“TEI viability testing”</a> section above for more information.
 
 <table><caption>Request settings</caption><thead><tr><th style="min-width:10%;">Name</th><th>Description</th><th>Where to set value</th></tr></thead><tbody><tr><th scope="row">project-id</th><td>The unique identifier of the project which owns the work.</td><td>URL</td></tr><tr><th scope="row">doc-id</th><td>A unique identifier for the document record attached to the original TEI document and 
 its derivatives (MODS, TFE).</td><td>URL</td></tr><tr><th scope="row">file</th><td>The TEI-encoded XML document to be stored.</td><td>form parameter</td></tr></tbody></table>
@@ -158,7 +158,7 @@ the view package’s configuration file for additional parameters.
 This endpoint returns generated XHTML with status code 200.
 
 If the provided file is not viable TEI, processing will halt with HTTP status code 422. See the 
-“TEI viability testing” section above for more information.
+<a href="#tei-viability-testing">“TEI viability testing”</a> section above for more information.
 
 <table><caption>Request settings</caption><thead><tr><th style="min-width:10%;">Name</th><th>Description</th><th>Where to set value</th></tr></thead><tbody><tr><th scope="row">type</th><td>A keyword representing the type of reader view to generate. Valid keywords can be found 
 by making a request to  the “List registered view packages” endpoint.</td><td>URL</td></tr><tr><th scope="row">file</th><td>A TEI-encoded XML document. The file parameter may become optional in the future, if a 

--- a/API.md
+++ b/API.md
@@ -1,5 +1,5 @@
 
-This documentation was generated from its <a href="https://github.com/NEU-DSG/tapas-xq/blob/develop/modules/tapas-api.xql">source code</a> on March 17th, 2026, 12:56 p.m. GMT-04:00.
+This documentation was generated from its <a href="https://github.com/NEU-DSG/tapas-xq/blob/develop/modules/tapas-api.xql">source code</a> on March 26th, 2026, 11:43 a.m. GMT-04:00.
 
 # TAPAS-xq API documentation
 
@@ -116,8 +116,8 @@ The TEI core file must be stored <em>before</em> any of its derivatives.
 
 This endpoint returns the MODS record derived from the TEI file, with status code 201.
 
-If no TEI document is associated with the given <code>doc-id</code>, a response with 
-HTTP status code 404 will be returned.
+If no TEI document is associated with the given <code>project-id</code> and 
+<code>doc-id</code>, a response with HTTP status code 404 will be returned.
 
 If something went wrong with the MODS transformation, the response will have a status code of 500. 
 If necessary, the TAPAS-xq maintainer should be alerted so they can fix the problem.
@@ -138,8 +138,8 @@ The TEI core file must be stored <em>before</em> any of its derivatives.
 
 This endpoint returns a URL path for reading the new TFE file through the TAPAS-xq API, with status code 201.
 
-If no TEI document is associated with the given <code>doc-id</code>, a response with 
-HTTP status code 404 will be returned.
+If no TEI document is associated with the given <code>project-id</code> and 
+<code>doc-id</code>, a response with HTTP status code 404 will be returned.
 
 <table><caption>Request settings</caption><thead><tr><th style="min-width:10%;">Name</th><th>Description</th><th>Where to set value</th></tr></thead><tbody><tr><th scope="row">project-id</th><td>The unique identifier of the project which owns the work.</td><td>URL</td></tr><tr><th scope="row">doc-id</th><td>A unique identifier for the document record attached to the original TEI document and 
 its derivatives.</td><td>URL</td></tr><tr><th scope="row">collections</th><td>Comma-separated list of collection identifiers with which the work should be 
@@ -177,8 +177,8 @@ Retrieve a TEI file stored in the XML database.
 
 This endpoint returns a copy of the TEI file, with status code 200.
 
-If no TEI document is associated with the given <code>doc-id</code>, a response with 
-HTTP status code 404 will be returned.
+If no TEI document is associated with the given <code>project-id</code> and 
+<code>doc-id</code>, a response with HTTP status code 404 will be returned.
 
 If the file is marked as private in the contextual metadata (TFE file), only users with write 
 access to the database will be able to access the file. An attempt at unauthorized access will 
@@ -194,8 +194,8 @@ Retrieve a MODS file associated with a given core file identifier.
 
 This endpoint returns a copy of the MODS metadata, with status code 200.
 
-If no TEI document is associated with the given <code>doc-id</code>, a response with 
-HTTP status code 404 will be returned.
+If no TEI document is associated with the given <code>project-id</code> and 
+<code>doc-id</code>, a response with HTTP status code 404 will be returned.
 
 If the file is marked as private in the contextual metadata (TFE file), only users with write 
 access to the database will be able to access the file. An attempt at unauthorized access will 
@@ -211,8 +211,8 @@ Retrieve a TAPAS-friendly environment (TFE) file associated with a given core fi
 
 This endpoint returns a copy of the TFE metadata, with status code 200.
 
-If no TEI document is associated with the given <code>doc-id</code>, a response with 
-HTTP status code 404 will be returned.
+If no TEI document is associated with the given <code>project-id</code> and 
+<code>doc-id</code>, a response with HTTP status code 404 will be returned.
 
 If the file is marked as private in the contextual metadata (TFE file), only users with write 
 access to the database will be able to access the file. An attempt at unauthorized access will 
@@ -229,8 +229,8 @@ MODS metadata, and TAPAS-friendly environment record.
 
 This endpoint returns a short confirmation in XML that the resources will be deleted, with status code 202.
 
-If no TEI document is associated with the given <code>doc-id</code>, a response with 
-HTTP status code 404 will be returned.
+If no TEI document is associated with the given <code>project-id</code> and 
+<code>doc-id</code>, a response with HTTP status code 404 will be returned.
 
 <table><caption>Request settings</caption><thead><tr><th style="min-width:10%;">Name</th><th>Description</th><th>Where to set value</th></tr></thead><tbody><tr><th scope="row">project-id</th><td>The identifier of the project which owns the core file.</td><td>URL</td></tr><tr><th scope="row">doc-id</th><td>The identifier of the TEI core file.</td><td>URL</td></tr></tbody></table>
 
@@ -242,7 +242,7 @@ Completely remove all database records associated with the given TAPAS project.
 
 This endpoint returns a short confirmation in XML that the resources will be deleted, with status code 202.
 
-If no TEI document is associated with the given <code>doc-id</code>, a response with 
+If no project is associated with the given <code>project-id</code>, a response with 
 HTTP status code 404 will be returned.
 
 <table><caption>Request settings</caption><thead><tr><th style="min-width:10%;">Name</th><th>Description</th><th>Where to set value</th></tr></thead><tbody><tr><th scope="row">project-id</th><td>The unique identifier of the project to be deleted.</td><td>URL</td></tr></tbody></table>

--- a/API.md
+++ b/API.md
@@ -1,5 +1,5 @@
 
-This documentation was generated from its <a href="https://github.com/NEU-DSG/tapas-xq/blob/develop/modules/tapas-api.xql">source code</a> on March 17th, 2026, 12:42 p.m. GMT-04:00.
+This documentation was generated from its <a href="https://github.com/NEU-DSG/tapas-xq/blob/develop/modules/tapas-api.xql">source code</a> on March 17th, 2026, 12:56 p.m. GMT-04:00.
 
 # TAPAS-xq API documentation
 
@@ -32,6 +32,7 @@ else. Processing will halt for any of the following cases:
 <li>The file is an unparsable binary file</li>
 <li>The file cannot be parsed as XML (it may be ill-formed)</li>
 <li>The file is parsable XML but one or more of the following is true:
+
 <ul>
 <li>The outermost element is not in the TEI namespace 
 (<code>http://www.tei-c.org/ns/1.0</code>)</li>
@@ -40,6 +41,7 @@ else. Processing will halt for any of the following cases:
 <li>There are multiple <code>teiHeader</code> elements</li>
 <li>An element named <code>script</code> is found in any namespace</li>
 </ul>
+
 </li>
 </ul>
 

--- a/API.md
+++ b/API.md
@@ -1,5 +1,5 @@
 
-This documentation was generated from its <a href="https://github.com/NEU-DSG/tapas-xq/blob/develop/modules/tapas-api.xql">source code</a> on March 17th, 2026, 12:23 p.m. GMT-04:00.
+This documentation was generated from its <a href="https://github.com/NEU-DSG/tapas-xq/blob/develop/modules/tapas-api.xql">source code</a> on March 17th, 2026, 12:42 p.m. GMT-04:00.
 
 # TAPAS-xq API documentation
 
@@ -16,9 +16,7 @@ All POST and DELETE requests <strong>must</strong> include an Authentication hea
 credentials for a BaseX user with write access to the TAPAS databases. If a request doesn’t meet this
 criteria, a response with an HTTP status code 401 will be returned.
 
-
 <h2 id="tei-viability-testing">TEI viability testing</h2>
-
 
 If an endpoint accepts TEI XML in a request, TAPAS-xq must receive a single, <a href="https://wwp.northeastern.edu/outreach/seminars/_current/presentations/xml_intro/xml_newIntro_tutorial_13.xhtml">well-formed</a> XML file, with <code>&lt;TEI xmlns="http://www.tei-c.org/ns/1.0"&gt;</code> 
 (<a href="https://en.wikipedia.org/wiki/XML_namespace#Namespace_declaration">or an equivalent</a>) as 

--- a/README.md
+++ b/README.md
@@ -101,6 +101,8 @@ If using the BaseX ZIP, unpack the archive and place the directory wherever you'
 
 If using the BaseX WAR, place the web archive in the `webapps` directory of [Apache Tomcat](https://tomcat.apache.org/). Then, start Tomcat in order to unpack the archive.
 
+You will need a modern Java JDK (Java Development Kit). The [OpenJDK implementation](https://openjdk.org/) is recommended. OpenJDK can be installed on a Mac with `brew install java`.
+
 To make full use of TAPAS-xq, you will need to configure BaseX further:
 
 - [Set up credentials for the BaseX "admin" account](#set-up-credentials-for-the-basex-admin-account)
@@ -212,7 +214,7 @@ bin/basex webapp/tapas-xq/modules/installation.bxs
 
 If you used the Tomcat WAR method of installing BaseX, you'll need to use `curl` to prompt BaseX to run the script, e.g.
 ```shell
-curl -X GET -u admin "http://localhost:8088/BaseX107/rest?run=tapas-xq/modules/installation.bxs"
+curl -X GET -u admin "http://localhost:8088/BaseX122/rest?run=tapas-xq/modules/installation.bxs"
 ```
 
 The [TAPAS-xq installation script](modules/installation.bxs) sets up the `tapas-data` and `tapas-view-packages` databases for you. It also sets up the "tapas" user (whose default password is "tapas"). The "tapas" user is the primary user of the TAPAS-xq; it is the account through which the TAPAS Rails service interacts with the TAPAS-xq databases.
@@ -220,3 +222,10 @@ The [TAPAS-xq installation script](modules/installation.bxs) sets up the `tapas-
 **Note:** Earlier versions of TAPAS-xq were installed by generating an [EXPath application "XAR file"](http://expath.org/spec/pkg#concepts). This method is no longer useful for installation, since BaseX doesn't register API endpoints when XQuery modules are installed from XARs. We have retained the [EXPath package descriptor](./expath-pkg.xml), which is still helpful for tracking versions and dependencies.
 
 
+### Working with BaseX and TAPAS-xq
+
+While the BaseX HTTP server is running, you can access BaseX's [Database Administration (DBA) page](http://localhost:8080/dba/login). You'll be prompted for a BaseX user name and password twice — once to access RESTXQ, and once to enter the DBA application. As the name implies, the interface is only accessible by users with "admin" permissions.
+
+The DBA interface gives you access to the BaseX logs, and information on the databases and users that BaseX knows about. You'll see two databases, `tapas-data` and `tapas-view-packages`, which were set up as part of the TAPAS-xq installation script. Besides the "admin" user, the installation script has also added a "tapas" user (pw: "tapas"), which can run XSLTs and write to both TAPAS databases.
+
+The TAPAS-xq API is available at <http://localhost:8080/tapas-xq>. It's a good idea to start by accessing the [API documentation](http://localhost:8080/tapas-xq/api) before preparing to test any requests with `curl` or some other tool. While it's possible to make requests with either the BaseX "admin" or "tapas" user credentials, I recommend using the "admin" account to monitor the database in the browser, and using the "tapas" account to simulate requests from the [TAPAS Rails](https://github.com/NEU-DSG/tapas_rails) service.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 TAPAS-xq
 ========
 
-TAPAS-xq is an EXPath application to manage [TEI](https://tei-c.org/)-encoded resources in an XML database. TAPAS-xq provides an API for the [Ruby on Rails component of TAPAS](https://github.com/NEU-DSG/tapas_rails) to accomplish tasks that are easier to do in an XML-native environment. Among these tasks:
+TAPAS-xq is an EXPath application to manage [TEI](https://tei-c.org/)-encoded resources in an XML database. TAPAS-xq provides an API for the [Ruby on Rails component of TAPAS](https://github.com/NEU-DSG/TAPAS) to accomplish tasks that are easier to do in an XML-native environment. Among these tasks:
 
 - Test that files are wellformed XML in the TEI namespace.
 - Store and index TEI files.
@@ -95,7 +95,7 @@ For local development work, you may wish to use the [Docker instructions](docker
 
 ### Setting up BaseX
 
-TAPAS-xq is designed to run in [BaseX](https://basex.org/), an open source XML database engine. [Download either the ZIP or WAR package](https://basex.org/download/) of BaseX at major semantic version 10 or 11.
+TAPAS-xq is designed to run in [BaseX](https://basex.org/), an open source XML database engine. [Download either the ZIP or WAR package](https://basex.org/download/) of the latest BaseX version. TAPAS-xq has most recently been tested on version 12.2.
 
 If using the BaseX ZIP, unpack the archive and place the directory wherever you'd like.
 
@@ -140,7 +140,7 @@ It's a little harder to set the admin password for the BaseX WAR installation. H
 
 BaseX will allow XSL 3.0 transformations if it finds a [Saxon processor](https://www.saxonica.com) on the classpath.
 
-To set this up, [download the latest Saxon HE package](https://github.com/Saxonica/Saxon-HE/releases) and unpack it. Place the extracted directory into `BASEX/lib/custom` (ZIP installation) or `BASEX/lib` (WAR installation). You'll need to restart BaseX so that it registers the library.
+To set this up, [download the latest Saxon HE package](https://github.com/Saxonica/Saxon-HE/releases) and unpack it. Copy all the contents of the Saxon HE directory into `BASEX/lib/custom` (ZIP installation) or `BASEX/lib` (WAR installation). You'll need to restart BaseX so that it registers the library.
 
 To make sure you've installed Saxon HE correctly, navigate to `BASE-URL/dba/editor` in your browser, and run `xslt:processor()`. You should see the result "Saxon HE", not "Java".
 
@@ -220,14 +220,3 @@ The [TAPAS-xq installation script](modules/installation.bxs) sets up the `tapas-
 **Note:** Earlier versions of TAPAS-xq were installed by generating an [EXPath application "XAR file"](http://expath.org/spec/pkg#concepts). This method is no longer useful for installation, since BaseX doesn't register API endpoints when XQuery modules are installed from XARs. We have retained the [EXPath package descriptor](./expath-pkg.xml), which is still helpful for tracking versions and dependencies.
 
 
-***
-
-## Hungry for more TAPAS?
-
-[TAPAS website](https://tapasproject.org/)
-
-[TAPAS Rails repository](https://github.com/NEU-DSG/tapas_rails)
-
-[TAPAS View Packages repository](https://github.com/NEU-DSG/tapas-view-packages)
-
-[Public documents, documentation, and meeting notes for TAPAS](https://github.com/NEU-DSG/tapas-docs)

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
-# Start from the AdoptOpenJDK image (v16), Ubuntu platform
-FROM adoptopenjdk/openjdk16:jre
+# Start from the Eclipse Temurin Java 25 image
+FROM eclipse-temurin:25
 
 # Install additional dependencies with the Ubuntu package manager
 RUN --mount=type=cache,target=/var/cache/apt \
@@ -14,20 +14,20 @@ WORKDIR /var/cache/basex
 
 # Download BaseX
 RUN --mount=type=cache,target=/var/cache/basex \
-    wget https://files.basex.org/releases/11.1/BaseX111.zip
+    wget https://files.basex.org/releases/12.2/BaseX122.zip
 
 # Unpack BaseX
 RUN --mount=type=cache,target=/var/cache/basex \
-    unzip BaseX111.zip -d /opt
+    unzip BaseX122.zip -d /opt
 
 # Download the Saxon HE processor
 WORKDIR /var/cache/saxonhe
 RUN --mount=type=cache,target=/var/cache/saxonhe \
-    wget https://github.com/Saxonica/Saxon-HE/releases/download/SaxonHE12-4/SaxonHE12-4J.zip
+    wget https://github.com/Saxonica/Saxon-HE/releases/download/SaxonHE12-9/SaxonHE12-9J.zip
 
 # Unpack Saxon HE where BaseX will find it
 RUN --mount=type=cache,target=/var/cache/saxonhe \
-    unzip SaxonHE12-4J.zip -d /opt/basex/lib/custom
+    unzip SaxonHE12-9J.zip -d /opt/basex/lib/custom
 
 # Copy the TAPAS-xq code into the container
 COPY ./ /opt/basex/webapp/tapas-xq
@@ -39,7 +39,7 @@ RUN /opt/basex/bin/basexhttp -c"PASSWORD admin" -S
 # Re-configure BaseX, requiring authentication for the RESTXQ endpoint
 WORKDIR /opt/basex/webapp/WEB-INF
 RUN cp web.xml web.xml.orig
-RUN java -jar /opt/basex/lib/custom/saxon-he-12.4.jar \
+RUN java -jar /opt/basex/lib/custom/saxon-he-12.9.jar \
       -s:web.xml.orig \
       -xsl:/opt/basex/webapp/tapas-xq/docker/configure-webapp.xsl \
       -o:web.xml
@@ -49,4 +49,4 @@ WORKDIR /opt/basex
 RUN bin/basex webapp/tapas-xq/modules/installation.bxs
 
 # When the Docker container starts up, run BaseX
-CMD /opt/basex/bin/basexhttp -h8080
+CMD ["/opt/basex/bin/basexhttp", "-h8080"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -52,7 +52,7 @@ HTTP Server was started (port: 8080).
 HTTP STOP Server was started (port: 8081).
 ```
 
-...you can visit BaseX's [Database Administration page](http://localhost:8080/dba/login). You'll be prompted for a BaseX user name and password twice — once to access RESTXQ, and once to enter the DBA application.
+...you can visit BaseX's [Database Administration page](http://localhost:8080/dba/login). You'll be prompted for a BaseX user name and password twice — once to access RESTXQ, and once to enter the DBA application. As the name implies, the interface is only accessible by users with "admin" permissions.
 
 The DBA interface gives you access to the BaseX logs, and information on the databases and users that BaseX knows about. You'll see two databases, `tapas-data` and `tapas-view-packages`, which were set up as part of the TAPAS-xq installation script. Besides the "admin" user, the installation script has also added a "tapas" user (pw: "tapas"), which can run XSLTs and write to both TAPAS databases.
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -23,7 +23,7 @@ Then, instruct Docker to use the `Dockerfile` in this folder to construct an ima
 docker build --file docker/Dockerfile --tag tapas-xq . 
 ```
 
-As part of this process, Docker follows the instructions given in [the Dockerfile](./Dockerfile). We start with a pre-built [Java JRE Docker container from AdoptOpenJDK](https://hub.docker.com/r/adoptopenjdk/openjdk16). From there, Docker:
+As part of this process, Docker follows the instructions given in [the Dockerfile](./Dockerfile). We start with a pre-built [Eclipse Temurin Docker container](https://hub.docker.com/_/eclipse-temurin). From there, Docker:
 
 * installs software packages for `git`, `unzip`, and `curl`;
 * installs BaseX and places a copy of the Saxon HE processor into its `lib/custom` directory;

--- a/docker/README.md
+++ b/docker/README.md
@@ -52,11 +52,7 @@ HTTP Server was started (port: 8080).
 HTTP STOP Server was started (port: 8081).
 ```
 
-...you can visit BaseX's [Database Administration page](http://localhost:8080/dba/login). You'll be prompted for a BaseX user name and password twice — once to access RESTXQ, and once to enter the DBA application. As the name implies, the interface is only accessible by users with "admin" permissions.
-
-The DBA interface gives you access to the BaseX logs, and information on the databases and users that BaseX knows about. You'll see two databases, `tapas-data` and `tapas-view-packages`, which were set up as part of the TAPAS-xq installation script. Besides the "admin" user, the installation script has also added a "tapas" user (pw: "tapas"), which can run XSLTs and write to both TAPAS databases.
-
-The TAPAS-xq API is available at <http://localhost:8080/tapas-xq>. It's a good idea to start by accessing the [API documentation](http://localhost:8080/tapas-xq/api) before preparing to test any requests with `curl` or some other tool. While it's possible to make requests with either the BaseX "admin" or "tapas" user credentials, I recommend using the "admin" account to monitor the database in the browser, and using the "tapas" account to simulate requests from the [TAPAS Rails](https://github.com/NEU-DSG/tapas_rails) service.
+...you can visit BaseX's [Database Administration page](http://localhost:8080/dba/login). Visit the TAPAS-xq README for more information on [working with BaseX and TAPAS-xq](../README.md#working-with-basex-and-tapas-xq).
 
 To stop the Docker container, hit the <kbd>Control</kbd> and <kbd>c</kbd> keys while inside the Terminal window where the Docker container is running.
 

--- a/modules/tapas-api.xql
+++ b/modules/tapas-api.xql
@@ -326,8 +326,8 @@ xquery version "3.1";
       separated by vertical bars.
     @return the MODS record derived from the TEI file, with status code 201.
       
-      If no TEI document is associated with the given <code class="param">doc-id</code>, a response with 
-      HTTP status code 404 will be returned.
+      If no TEI document is associated with the given <code class="param">project-id</code> and 
+      <code class="param">doc-id</code>, a response with HTTP status code 404 will be returned.
       
       If something went wrong with the MODS transformation, the response will have a status code of 500. 
       If necessary, the TAPAS-xq maintainer should be alerted so they can fix the problem.
@@ -377,8 +377,8 @@ xquery version "3.1";
       document belongs to even one public collection, it should be queryable.)
     @return a URL path for reading the new TFE file through the TAPAS-xq API, with status code 201.
       
-      If no TEI document is associated with the given <code class="param">doc-id</code>, a response with 
-      HTTP status code 404 will be returned.
+      If no TEI document is associated with the given <code class="param">project-id</code> and 
+      <code class="param">doc-id</code>, a response with HTTP status code 404 will be returned.
    :)
   (: Originally ../legacy/store-tfe.xq :)
   declare
@@ -484,8 +484,8 @@ xquery version "3.1";
     @param doc-id The identifier of the TEI core file.
     @return a copy of the TEI file, with status code 200.
       
-      If no TEI document is associated with the given <code class="param">doc-id</code>, a response with 
-      HTTP status code 404 will be returned.
+      If no TEI document is associated with the given <code class="param">project-id</code> and 
+      <code class="param">doc-id</code>, a response with HTTP status code 404 will be returned.
       
       If the file is marked as private in the contextual metadata (TFE file), only users with write 
       access to the database will be able to access the file. An attempt at unauthorized access will 
@@ -511,8 +511,8 @@ xquery version "3.1";
     @param doc-id The identifier of the TEI core file.
     @return a copy of the MODS metadata, with status code 200.
       
-      If no TEI document is associated with the given <code class="param">doc-id</code>, a response with 
-      HTTP status code 404 will be returned.
+      If no TEI document is associated with the given <code class="param">project-id</code> and 
+      <code class="param">doc-id</code>, a response with HTTP status code 404 will be returned.
       
       If the file is marked as private in the contextual metadata (TFE file), only users with write 
       access to the database will be able to access the file. An attempt at unauthorized access will 
@@ -538,8 +538,8 @@ xquery version "3.1";
     @param doc-id The identifier of the TEI core file.
     @return a copy of the TFE metadata, with status code 200.
       
-      If no TEI document is associated with the given <code class="param">doc-id</code>, a response with 
-      HTTP status code 404 will be returned.
+      If no TEI document is associated with the given <code class="param">project-id</code> and 
+      <code class="param">doc-id</code>, a response with HTTP status code 404 will be returned.
       
       If the file is marked as private in the contextual metadata (TFE file), only users with write 
       access to the database will be able to access the file. An attempt at unauthorized access will 
@@ -566,8 +566,8 @@ xquery version "3.1";
     @param doc-id The identifier of the TEI core file.
     @return a short confirmation in XML that the resources will be deleted, with status code 202.
       
-      If no TEI document is associated with the given <code class="param">doc-id</code>, a response with 
-      HTTP status code 404 will be returned.
+      If no TEI document is associated with the given <code class="param">project-id</code> and 
+      <code class="param">doc-id</code>, a response with HTTP status code 404 will be returned.
    :)
   (: Originally ../legacy/delete-by-docid.xq :)
   declare
@@ -606,7 +606,7 @@ xquery version "3.1";
     @param project-id The unique identifier of the project to be deleted.
     @return a short confirmation in XML that the resources will be deleted, with status code 202.
       
-      If no TEI document is associated with the given <code class="param">doc-id</code>, a response with 
+      If no project is associated with the given <code class="param">project-id</code>, a response with 
       HTTP status code 404 will be returned.
    :)
   (: Originally ../legacy/delete-by-projid.xq :)

--- a/modules/tapas-api.xql
+++ b/modules/tapas-api.xql
@@ -41,7 +41,7 @@ xquery version "3.1";
   credentials for a BaseX user with write access to the TAPAS databases. If a request doesn’t meet this
   criteria, a response with an HTTP status code 401 will be returned.
   
-  <h2>TEI viability testing</h2>
+  <h2 id="tei-viability-testing">TEI viability testing</h2>
   
   If an endpoint accepts TEI XML in a request, TAPAS-xq must receive a single, <a 
   href="https://wwp.northeastern.edu/outreach/seminars/_current/presentations/xml_intro/xml_newIntro_tutorial_13.xhtml"
@@ -209,7 +209,7 @@ xquery version "3.1";
     @return the MODS record derived from the TEI file, with HTTP status code 201.
       
       If the provided file is not viable TEI, processing will halt with HTTP status code 422. See the 
-      “TEI viability testing” section above for more information.
+      <a href="#tei-viability-testing">“TEI viability testing”</a> section above for more information.
       
       If the MODS file could not be generated because of a problem with the XSLT stylesheet, an HTTP 
       status code 500 will be returned. If necessary, the TAPAS-xq maintainer should be alerted so they 
@@ -278,7 +278,7 @@ xquery version "3.1";
     @return a URL path for accessing the stored TEI file through the TAPAS-xq API, with status code 201.
       
       If the provided file is not viable TEI, processing will halt with HTTP status code 422. See the 
-      “TEI viability testing” section above for more information.
+      <a href="#tei-viability-testing">“TEI viability testing”</a> section above for more information.
    :)
   (: Originally ../legacy/store-tei.xq :)
   declare
@@ -422,7 +422,7 @@ xquery version "3.1";
     @return generated XHTML with status code 200.
       
       If the provided file is not viable TEI, processing will halt with HTTP status code 422. See the 
-      “TEI viability testing” section above for more information.
+      <a href="#tei-viability-testing">“TEI viability testing”</a> section above for more information.
    :)
   (: Originally ../legacy/derive-reader.xq :)
   declare

--- a/modules/tapas-api.xql
+++ b/modules/tapas-api.xql
@@ -126,11 +126,16 @@ xquery version "3.1";
   function tap:get-documentation($format as xs:string?) {
     let $successCode := 200
     let $formatAsMarkdown := lower-case($format) eq 'markdown'
-    let $xqDocXML := inspect:xqdoc('tapas-api.xql')
-    (: Test for a bug in BaseX 11.0 where every <xqdoc:description> contains only digits, not readable 
-      text. :)
-    let $useFallback := 
-      $xqDocXML//Q{http://www.xqdoc.org/1.0}description[1][not(contains(., ' '))]
+    let $xqDocXML := 
+      try { inspect:xqdoc('tapas-api.xql') }
+      (: If the BaseX user doesn't have admin privileges, recover. :)
+      catch basex:permission { () }
+    (: If there was a permissions issue, dynamically generating XQDoc documentation is not an option. 
+      We'll need to use a fallback. :)
+    let $useFallback := empty($xqDocXML) or
+      (: A fallback is also needed if <xqdoc:description> contains only digits, not readable text. (This 
+        was a bug in BaseX v11.) :)
+      exists($xqDocXML//Q{http://www.xqdoc.org/1.0}description[1][not(contains(., ' '))])
     let $outputDocs := 
       let $params := map {
           'html-title': "TAPAS-xq API",

--- a/modules/tapas-api.xql
+++ b/modules/tapas-api.xql
@@ -37,14 +37,22 @@ xquery version "3.1";
   concerned with the program component, and the configuration file which defines how to execute that 
   program.
   
-  If an endpoint accepts TEI XML in a request, TAPAS-xq must receive a single, well-formed XML file, 
-  with <code>&lt;TEI xmlns="http://www.tei-c.org/ns/1.0"&gt;</code> (or an equivalent) as the outermost 
-  element, and exactly one <code>&lt;teiHeader&gt;</code>. No arbitrary Javascript is allowed. TAPAS-xq 
-  does not, however, validate the file against a full TEI schema. This allows TAPAS users to upload 
-  files that adhere to arbitrary (modern) TEI versions, or even their own custom schemas.
+  All POST and DELETE requests <strong>must</strong> include an Authentication header containing the 
+  credentials for a BaseX user with write access to the TAPAS databases. If a request doesn’t meet this
+  criteria, a response with an HTTP status code 401 will be returned.
+  
+  <h2>TEI viability testing</h2>
+  
+  If an endpoint accepts TEI XML in a request, TAPAS-xq must receive a single, <a 
+  href="https://wwp.northeastern.edu/outreach/seminars/_current/presentations/xml_intro/xml_newIntro_tutorial_13.xhtml"
+  >well-formed</a> XML file, with <code>&lt;TEI xmlns="http://www.tei-c.org/ns/1.0"&gt;</code> 
+  (<a href="https://en.wikipedia.org/wiki/XML_namespace#Namespace_declaration">or an equivalent</a>) as 
+  the outermost element, and exactly one <code>&lt;teiHeader&gt;</code>. No arbitrary Javascript is 
+  allowed. TAPAS-xq does not, however, validate the file against a full TEI schema. This allows TAPAS 
+  users to upload files that adhere to arbitrary (modern) TEI versions, or even their own custom schemas.
   
   TAPAS-xq will run minimal validation processes on a request’s file parameter before doing anything 
-  else. Processing will halt and a 422 error will be returned for any of the following cases:
+  else. Processing will halt for any of the following cases:
   
   <ul>
     <li>Multiple files are identified</li>
@@ -62,9 +70,8 @@ xquery version "3.1";
     </li>
   </ul>
   
-  All POST and DELETE requests <strong>must</strong> include an Authentication header containing the 
-  credentials for a BaseX user with write access to the TAPAS databases. If a request doesn’t meet this
-  criteria, a response with an HTTP status code 401 will be returned.
+  When a test failure occurs, HTTP status code 422 will be returned. The response body will contain a 
+  description of identified problems.
   
   @author Ash Clark
   @since 2023
@@ -108,10 +115,12 @@ xquery version "3.1";
  :)
   
   (:~
-    Generate documentation for the TAPAS-xq API, in XHTML or Markdown.
+    Generate documentation for the TAPAS-xq API, in XHTML or Markdown. If the user has administrator 
+    privileges, this documentation is generated dynamically from the RESTXQ code. Otherwise, a cached 
+    HTML or Markdown file is used.
     
     @param format The formatting method to use when producing documentation. Valid options are 
-      "markdown" or "html". The default is to return XHTML.
+      "markdown" or "html". The default is to return HTML, in XHTML format.
     @return a representation of the API documentation, with status code 200.
    :)
   (: NOTE: Because we're producing two wildly different formats of documentation at the same endpoint, 
@@ -126,19 +135,26 @@ xquery version "3.1";
   function tap:get-documentation($format as xs:string?) {
     let $successCode := 200
     let $formatAsMarkdown := lower-case($format) eq 'markdown'
+    (: Try dynamically generating the API documentation, but recover from any errors. :)
     let $xqDocXML := 
       try { inspect:xqdoc('tapas-api.xql') }
-      (: If the BaseX user doesn't have admin privileges, recover. :)
+      (: Starting in BaseX v12, the `inspect:xqdoc()` function can only be run by administrators. :)
       catch basex:permission { () }
-    (: If there was a permissions issue, dynamically generating XQDoc documentation is not an option. 
-      We'll need to use a fallback. :)
+      (: Also recover from other errors, but make sure the error is recorded in the logs, e.g.
+          TRACE   TAPAS-xq recovery: "basex:permission in tapas-api.xql line 143. No admin permission: inspect:xqdoc(""tapas-api.xql"")."
+        (Tested by commenting out the basex:permission catch above.) :)
+      catch * {
+          let $logMsg := $err:code || " in " || $err:module || " line " || $err:line-number || ". "
+            || $err:description
+          return message($logMsg, "TAPAS-xq recovery")
+        }
+    (: If dynamically generating XQDoc documentation is not an option, we'll need to use a fallback. :)
     let $useFallback := empty($xqDocXML) or
       (: A fallback is also needed if <xqdoc:description> contains only digits, not readable text. (This 
         was a bug in BaseX v11.) :)
       exists($xqDocXML//Q{http://www.xqdoc.org/1.0}description[1][not(contains(., ' '))])
     let $outputDocs := 
       let $params := map {
-          'html-title': "TAPAS-xq API",
           'source-code-url':
             "https://github.com/NEU-DSG/tapas-xq/blob/develop/modules/tapas-api.xql"
         }
@@ -190,9 +206,14 @@ xquery version "3.1";
       by vertical bars.
     @param contributors Optional. A list of contributors’ names as they should appear in TAPAS metadata, 
       separated by vertical bars.
-    @return the MODS record derived from the TEI file, with HTTP status code 201. Any problems with the 
-      TEI file will result in a response code of 500. If the MODS file could not be generated due to 
-      transformation issues, the TEI and TFE files will still be stored despite the response error code.
+    @return the MODS record derived from the TEI file, with HTTP status code 201.
+      
+      If the provided file is not viable TEI, processing will halt with HTTP status code 422. See the 
+      “TEI viability testing” section above for more information.
+      
+      If the MODS file could not be generated because of a problem with the XSLT stylesheet, an HTTP 
+      status code 500 will be returned. If necessary, the TAPAS-xq maintainer should be alerted so they 
+      can fix the problem. The TEI and TFE files will be stored regardless.
    :)
   declare
     %updating
@@ -255,6 +276,9 @@ xquery version "3.1";
       its derivatives (MODS, TFE).
     @param file The TEI-encoded XML document to be stored.
     @return a URL path for accessing the stored TEI file through the TAPAS-xq API, with status code 201.
+      
+      If the provided file is not viable TEI, processing will halt with HTTP status code 422. See the 
+      “TEI viability testing” section above for more information.
    :)
   (: Originally ../legacy/store-tei.xq :)
   declare
@@ -393,9 +417,12 @@ xquery version "3.1";
     
     @param type A keyword representing the type of reader view to generate. Valid keywords can be found 
       by making a request to  the “List registered view packages” endpoint.
-    @param file A TEI-encoded XML document. If, in the future, a view package makes use of a different 
-      input source (such as a TAPAS collection or a project), the file parameter may become optional.
+    @param file A TEI-encoded XML document. The file parameter may become optional in the future, if a 
+      view package makes use of a different input source (such as a TAPAS collection or a project).
     @return generated XHTML with status code 200.
+      
+      If the provided file is not viable TEI, processing will halt with HTTP status code 422. See the 
+      “TEI viability testing” section above for more information.
    :)
   (: Originally ../legacy/derive-reader.xq :)
   declare

--- a/modules/tapas-api.xql
+++ b/modules/tapas-api.xql
@@ -37,6 +37,31 @@ xquery version "3.1";
   concerned with the program component, and the configuration file which defines how to execute that 
   program.
   
+  If an endpoint accepts TEI XML in a request, TAPAS-xq must receive a single, well-formed XML file, 
+  with <code>&lt;TEI xmlns="http://www.tei-c.org/ns/1.0"&gt;</code> (or an equivalent) as the outermost 
+  element, and exactly one <code>&lt;teiHeader&gt;</code>. No arbitrary Javascript is allowed. TAPAS-xq 
+  does not, however, validate the file against a full TEI schema. This allows TAPAS users to upload 
+  files that adhere to arbitrary (modern) TEI versions, or even their own custom schemas.
+  
+  TAPAS-xq will run minimal validation processes on a request’s file parameter before doing anything 
+  else. Processing will halt and a 422 error will be returned for any of the following cases:
+  
+  <ul>
+    <li>Multiple files are identified</li>
+    <li>The file is an unparsable binary file</li>
+    <li>The file cannot be parsed as XML (it may be ill-formed)</li>
+    <li>The file is parsable XML but one or more of the following is true:
+      <ul>
+        <li>The outermost element is not in the TEI namespace 
+          (<code>http://www.tei-c.org/ns/1.0</code>)</li>
+        <li>The outermost element’s name is not <code>TEI</code></li>
+        <li>There is no <code>teiHeader</code> element</li>
+        <li>There are multiple <code>teiHeader</code> elements</li>
+        <li>An element named <code>script</code> is found in any namespace</li>
+      </ul>
+    </li>
+  </ul>
+  
   All POST and DELETE requests <strong>must</strong> include an Authentication header containing the 
   credentials for a BaseX user with write access to the TAPAS databases. If a request doesn’t meet this
   criteria, a response with an HTTP status code 401 will be returned.
@@ -271,8 +296,8 @@ xquery version "3.1";
     @param contributors Optional. A list of contributors’ names as they should appear in TAPAS metadata, 
       separated by vertical bars.
     @return the MODS record derived from the TEI file, with status code 201. If no TEI document is 
-      associated with the given <code class="param">doc-id</code>, the response will have a status code 
-      of 500.
+      associated with the given <code class="param">doc-id</code>, or if something went wrong with the 
+      MODS transformation, the response will have a status code of 500.
    :)
   (: Originally ../legacy/store-mods.xq :)
   declare

--- a/modules/tapas-api.xql
+++ b/modules/tapas-api.xql
@@ -324,9 +324,13 @@ xquery version "3.1";
       by vertical bars.
     @param contributors Optional. A list of contributors’ names as they should appear in TAPAS metadata, 
       separated by vertical bars.
-    @return the MODS record derived from the TEI file, with status code 201. If no TEI document is 
-      associated with the given <code class="param">doc-id</code>, or if something went wrong with the 
-      MODS transformation, the response will have a status code of 500.
+    @return the MODS record derived from the TEI file, with status code 201.
+      
+      If no TEI document is associated with the given <code class="param">doc-id</code>, a response with 
+      HTTP status code 404 will be returned.
+      
+      If something went wrong with the MODS transformation, the response will have a status code of 500. 
+      If necessary, the TAPAS-xq maintainer should be alerted so they can fix the problem.
    :)
   (: Originally ../legacy/store-mods.xq :)
   declare
@@ -371,9 +375,10 @@ xquery version "3.1";
     @param is-public Optional. Value of “true” or “false”. Indicates if the XML document should be 
       queryable by the public. By default, the document is considered private. (Note that if the 
       document belongs to even one public collection, it should be queryable.)
-    @return a URL path for reading the new TFE file through the TAPAS-xq API, with status code 201. If 
-      no TEI document is associated with the given <code class="param">doc-id</code>, the response will 
-      have a status code of 500.
+    @return a URL path for reading the new TFE file through the TAPAS-xq API, with status code 201.
+      
+      If no TEI document is associated with the given <code class="param">doc-id</code>, a response with 
+      HTTP status code 404 will be returned.
    :)
   (: Originally ../legacy/store-tfe.xq :)
   declare
@@ -477,8 +482,10 @@ xquery version "3.1";
     
     @param project-id The identifier of the project which owns the core file.
     @param doc-id The identifier of the TEI core file.
-    @return a copy of the TEI file, with status code 200. If the file does not exist, the response will 
-      have a status code of 404.
+    @return a copy of the TEI file, with status code 200.
+      
+      If no TEI document is associated with the given <code class="param">doc-id</code>, a response with 
+      HTTP status code 404 will be returned.
       
       If the file is marked as private in the contextual metadata (TFE file), only users with write 
       access to the database will be able to access the file. An attempt at unauthorized access will 
@@ -502,8 +509,10 @@ xquery version "3.1";
     
     @param project-id The identifier of the project which owns the core file.
     @param doc-id The identifier of the TEI core file.
-    @return a copy of the MODS metadata, with status code 200. If the file does not exist, the response 
-      will have a status code of 404.
+    @return a copy of the MODS metadata, with status code 200.
+      
+      If no TEI document is associated with the given <code class="param">doc-id</code>, a response with 
+      HTTP status code 404 will be returned.
       
       If the file is marked as private in the contextual metadata (TFE file), only users with write 
       access to the database will be able to access the file. An attempt at unauthorized access will 
@@ -527,8 +536,10 @@ xquery version "3.1";
     
     @param project-id The identifier of the project which owns the core file.
     @param doc-id The identifier of the TEI core file.
-    @return a copy of the TFE metadata, with status code 200. If the file does not exist, the response 
-      will have a status code of 404.
+    @return a copy of the TFE metadata, with status code 200.
+      
+      If no TEI document is associated with the given <code class="param">doc-id</code>, a response with 
+      HTTP status code 404 will be returned.
       
       If the file is marked as private in the contextual metadata (TFE file), only users with write 
       access to the database will be able to access the file. An attempt at unauthorized access will 
@@ -553,8 +564,10 @@ xquery version "3.1";
     
     @param project-id The identifier of the project which owns the core file.
     @param doc-id The identifier of the TEI core file.
-    @return a short confirmation in XML that the resources will be deleted, with status code 202. If no 
-      TEI document is associated with the given identifier, the response will have a status code of 500.
+    @return a short confirmation in XML that the resources will be deleted, with status code 202.
+      
+      If no TEI document is associated with the given <code class="param">doc-id</code>, a response with 
+      HTTP status code 404 will be returned.
    :)
   (: Originally ../legacy/delete-by-docid.xq :)
   declare
@@ -565,8 +578,8 @@ xquery version "3.1";
     %output:media-type("application/xml")
   function tap:delete-core-file($project-id as xs:string, $doc-id as xs:string) {
     (: Originally, this endpoint returned a 200 response, since it could check to make sure that the 
-    file was gone after deletion. The "202 Accepted" response is more appropriate now, since we can only 
-    promise that we *will* delete the item, we can't say that we *have done* it. :)
+      file was gone after deletion. The "202 Accepted" response is more appropriate now, since we can 
+      only promise that we *will* delete the item, we can't say that we *have done* it. :)
     let $successCode := 202
     let $response := 
       let $teiDoc := tap:get-stored-xml($project-id, $doc-id)
@@ -591,8 +604,10 @@ xquery version "3.1";
     Completely remove all database records associated with the given TAPAS project.
     
     @param project-id The unique identifier of the project to be deleted.
-    @return a short confirmation in XML that the resources will be deleted, with status code 202. If no 
-      TEI document is associated with the given identifier, the response will have a status code of 500.
+    @return a short confirmation in XML that the resources will be deleted, with status code 202.
+      
+      If no TEI document is associated with the given <code class="param">doc-id</code>, a response with 
+      HTTP status code 404 will be returned.
    :)
   (: Originally ../legacy/delete-by-projid.xq :)
   declare
@@ -680,9 +695,10 @@ xquery version "3.1";
     Retrieve the configuration file for a given view package.
     
     @param package-id The identifier of the view package.
-    @return the XML configuration file of the view package with status code 200. If the requested 
-      identifier does not match a view package registered with TAPAS-xq, the response will have a status 
-      code of 400.
+    @return the XML configuration file of the view package with status code 200. 
+      
+      If the requested identifier does not match a view package registered with TAPAS-xq, the response 
+      will have an HTTP status code of 400.
    :)
   declare
     %rest:GET

--- a/resources/xqdoc-to-api-docs.xsl
+++ b/resources/xqdoc-to-api-docs.xsl
@@ -175,9 +175,20 @@
     </xsl:variable>
     <xsl:for-each-group select="$paragraphsMarked" 
        group-ending-with="*:br[@class eq 'paragraph-boundary']">
-      <p>
+      <xsl:variable name="content" as="node()*">
         <xsl:apply-templates select="current-group()" mode="remove-paragraph-boundaries"/>
-      </p>
+      </xsl:variable>
+      <xsl:choose>
+        <!-- If this is an <h2> element, we shouldn't wrap it in <p>. -->
+        <xsl:when test="current-group()[self::*:h2]">
+          <xsl:sequence select="$content"/>
+        </xsl:when>
+        <xsl:otherwise>
+          <p>
+            <xsl:sequence select="$content"/>
+          </p>
+        </xsl:otherwise>
+      </xsl:choose>
     </xsl:for-each-group>
   </xsl:template>
   

--- a/resources/xqdoc-to-api-docs.xsl
+++ b/resources/xqdoc-to-api-docs.xsl
@@ -25,7 +25,7 @@
    -->
   
   <!-- The title of the output webpage. -->
-  <xsl:param name="html-title" select="'TAPAS-xq API'" as="xs:string?"/>
+  <xsl:param name="html-title" select="'TAPAS-xq API documentation'" as="xs:string?"/>
   
   <!-- A URL to the XQuery which is considered the source of the xqDoc XML. If a URL is provided, a link 
     to the XQuery is included along with the generation statement. -->
@@ -88,7 +88,9 @@
           </p>
         </aside>
         <main>
-          <h1>API documentation</h1>
+          <h1>
+            <xsl:value-of select="$html-title"/>
+          </h1>
           <xsl:apply-templates select="//module/comment"/>
           <h2 id="all-endpoints">Request endpoints</h2>
           <xsl:apply-templates select="//functions"/>

--- a/resources/xqdoc-to-api-docs.xsl
+++ b/resources/xqdoc-to-api-docs.xsl
@@ -179,8 +179,8 @@
         <xsl:apply-templates select="current-group()" mode="remove-paragraph-boundaries"/>
       </xsl:variable>
       <xsl:choose>
-        <!-- If this is an <h2> element, we shouldn't wrap it in <p>. -->
-        <xsl:when test="current-group()[self::*:h2]">
+        <!-- Some (namespace-less) elements shouldn't be wrapped in <p>. -->
+        <xsl:when test="current-group()[local-name(.) = ('h2', 'ul')]">
           <xsl:sequence select="$content"/>
         </xsl:when>
         <xsl:otherwise>

--- a/resources/xqdoc-to-api-docs.xsl
+++ b/resources/xqdoc-to-api-docs.xsl
@@ -92,7 +92,7 @@
             <xsl:value-of select="$html-title"/>
           </h1>
           <xsl:apply-templates select="//module/comment"/>
-          <h2 id="all-endpoints">Request endpoints</h2>
+          <h2 id="request-endpoints">Request endpoints</h2>
           <xsl:apply-templates select="//functions"/>
         </main>
       </body>

--- a/resources/xqdoc-to-markdown.xsl
+++ b/resources/xqdoc-to-markdown.xsl
@@ -65,7 +65,7 @@
   </xsl:template>
   
   <!-- Strip the namespaces from XHTML elements by default. -->
-  <xsl:template match="*" mode="markdown">
+  <xsl:template match="*" mode="markdown" name="copy-element">
     <xsl:element name="{local-name(.)}">
       <xsl:apply-templates select="@*" mode="#current"/>
       <xsl:apply-templates mode="#current"/>
@@ -91,6 +91,13 @@
     <xsl:value-of select="$newline"/>
     <xsl:text>## </xsl:text>
     <xsl:value-of select="normalize-space(.)"/>
+    <xsl:value-of select="$newline"/>
+  </xsl:template>
+  
+  <!-- Don't convert <h2> elements to Markdown if their IDs would be lost on conversion. -->
+  <xsl:template match="h2[@id]" mode="markdown" priority="2">
+    <xsl:value-of select="$newline"/>
+    <xsl:call-template name="copy-element"/>
     <xsl:value-of select="$newline"/>
   </xsl:template>
   

--- a/resources/xqdoc-to-markdown.xsl
+++ b/resources/xqdoc-to-markdown.xsl
@@ -114,12 +114,10 @@
     <xsl:value-of select="$newline"/>
   </xsl:template>
   
-  <!-- We'll keep the <table> mostly as-is, rather than try to convert it to Markdown. -->
-  <xsl:template match="table" mode="markdown">
+  <!-- We'll keep the <table> and <ul> mostly as-is, rather than try to convert them to Markdown. -->
+  <xsl:template match="table | ul" mode="markdown">
     <xsl:value-of select="$newline"/>
-    <xsl:element name="table">
-      <xsl:apply-templates mode="#current"/>
-    </xsl:element>
+    <xsl:next-match/>
     <xsl:value-of select="$newline"/>
   </xsl:template>
   


### PR DESCRIPTION
Closes #29. Closes #28.

This PR is primarily about updating documentation: the Readmes and the API docs. The API documentation now describes the pre-processing checks that TAPAS-xq runs on an uploaded XML file. The resulting HTTP codes and error messages are also described, and a few errors have been corrected. In addition, TAPAS-xq now works with the most current version of BaseX, v12.2. The Docker configuration has been updated to match.

### For the reviewer

Because this PR is focused on documentation, I'm mostly concerned with readability, and filling in gaps. As you read, please note any questions or confusing areas of the documentation.

A lot of changes are repeated between [API.md](https://github.com/NEU-DSG/tapas-xq/blob/upgrade-and-update-api-docs/API.md) and API.html (the derivatives), and `modules/tapas-api.xql` (the source). I recommend choosing only one of the three to read in the file diff.

Feel free to skip the XSLT and XQuery code edits. They support the docs updates, and access to the docs, but I don't consider them essential to review.


### Significant changes

- The API documentation contains a section on how TAPAS-xq tests incoming XML files for well-formedness and validity.
    - Endpoints that take XML files as parameters link back to this new section.
    - In general, the API documentation does better at listing endpoints' responses in the case of specific errors.
- Information on how to work with BaseX and TAPAS-xq has been moved from the Docker Readme to the repository Readme.
- TAPAS-xq now works in BaseX v12.2. It continues to work in v11.0 (and probably still works in v10, though I didn't test it).
    - The function I use to generate the API documentation can only be used by BaseX administrators. If you're using BaseX v12, you will only see a freshly-generated page by logging in as the `admin` user.
        - The API endpoint recovers from permissions issues and errors by supplying the HTML or Markdown files saved to the repository.
    - Docker installation
        - The Docker configuration uses the most up-to-date versions of BaseX (v12.2) and Saxon HE (v12.9).
        - The Docker configuration also uses a different base image, Eclipse Temurin, for access to Java OpenJDK v25.
- The XSLT stylesheets to generate HTML and Markdown documentation now retain elements with IDs, and do a better job producing valid HTML.